### PR TITLE
Quick fix to broken docs

### DIFF
--- a/qawolf/Full-Service-The-First-Three-Months-29c5b2a994fb81bb9e10e4182639f294.mdx
+++ b/qawolf/Full-Service-The-First-Three-Months-29c5b2a994fb81bb9e10e4182639f294.mdx
@@ -109,7 +109,7 @@ Within 5 business days of the contract start date.
 
 These blockers can slow down onboarding progress. Please address them as soon as possible:
 
-- Your testing environment is unavailable, misconfigured, or unresponsive. Read [🎯 Preparing an environment for QA Wolf test runs](qawolf/Test-environments-2dc5b2a994fb800e8ce4fe36ee34764a)
+- Your testing environment is unavailable, misconfigured, or unresponsive. Read [🎯 Preparing an environment for QA Wolf test runs](/qawolf/Test-environments-2dc5b2a994fb800e8ce4fe36ee34764a)
 - Your environment is not able to send emails to the @qawolf.email domain.
 
 ## Implementation
@@ -201,4 +201,4 @@ Within 20 business days of the contract start date.
 ### 💀 Common test creation blockers
 
 - Your test environment is too unstable to run end-to-end tests reliably.
-  - Read: [🎯Preparing an environment for QA Wolf test runs](qawolf/Test-environments-2dc5b2a994fb800e8ce4fe36ee34764a)
+  - Read: [🎯Preparing an environment for QA Wolf test runs](/qawolf/Test-environments-2dc5b2a994fb800e8ce4fe36ee34764a)

--- a/qawolf/Full-Service-The-First-Three-Months-29c5b2a994fb81bb9e10e4182639f294.mdx
+++ b/qawolf/Full-Service-The-First-Three-Months-29c5b2a994fb81bb9e10e4182639f294.mdx
@@ -33,7 +33,7 @@ Connect your Slack, Teams, or Discord account with QA Wolf.
 <Step>
 Send test environment credentials to your Account Executive, QA Engineering Lead, or Customer Success Manager.
 
-    - Read: [🎯Preparing an environment for QA Wolf test runs](qawolf/Test-environments-2dc5b2a994fb800e8ce4fe36ee34764a)
+    - Read: [🎯Preparing an environment for QA Wolf test runs](/qawolf/Test-environments-2dc5b2a994fb800e8ce4fe36ee34764a)
     - Read: [📖QA Wolf Docs - Which environment should we run our tests on?](/qawolf/Choose-the-right-CI-environment-to-execute-your-tests-29c5b2a994fb8031a3ddc1355eb4e7be)
 </Step>
 <Step>

--- a/qawolf/Workspace-settings-2d25b2a994fb807fbd9bece4eb1a4d5f.mdx
+++ b/qawolf/Workspace-settings-2d25b2a994fb807fbd9bece4eb1a4d5f.mdx
@@ -91,7 +91,7 @@ sidebarTitle: "Workspace settings"
 ## How to create, rename, and delete environments
 
 <Tip>
-  A workspace can include multiple [environments](qawolf/Glossary-29c5b2a994fb806d93f2ce4554a2fcfc#environment).
+  A workspace can include multiple [environments](/qawolf/Glossary-29c5b2a994fb806d93f2ce4554a2fcfc#environment).
 
   Environments can be static or ephemeral (preview). The default environment is called _My Environment_. We recommended that you create a new environment to match the testing environment in your pipeline and delete _My Environment_. Create additional environments if you test at multiple stages of a release.
 </Tip>


### PR DESCRIPTION
mintlify broken-links doesn't catch these

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/qawolf/qawolf/editor/fix-broken-links?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->