### PR TITLE
Update web launch flow docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -140,6 +140,7 @@
             "group": "Mobile-native media",
             "icon": "tablet-smartphone",
             "pages": [
+              "qawolf/mobile-native-media",
               {
                 "group": "Photo library management",
                 "icon": "image",

--- a/qawolf/libraries/flows/api-reference/web.mdx
+++ b/qawolf/libraries/flows/api-reference/web.mdx
@@ -11,6 +11,9 @@ sidebarTitle: "Web Reference"
 - `flow(...)`
 - `launch(...)`
 - `expect`
+- `isAnonymous(...)`
+- `isPersistent(...)`
+- `isElectron(...)`
 - `testContextDependencies`
 
 It also exports web-specific target, launch, callback context, and flow definition types.
@@ -42,22 +45,26 @@ type WebFlowTargetInput =
       launch?: false | undefined;
     }
   | {
-      target: WebFlowTarget;
-      launch: true | LaunchOptions;
+      target: WebBrowserFlowTarget;
+      launch: true | BrowserLaunchOptions;
+    }
+  | {
+      target: WebElectronFlowTarget;
+      launch: ElectronFlowLaunchOptions;
     };
 ```
 
 Examples:
 
 ```ts
-import { flow, launch } from "@qawolf/flows/web";
+import { flow, isElectron, isPersistent, launch } from "@qawolf/flows/web";
 
 export const manualLaunchFlow = flow("Open later", "Web - Chrome", async () => {
   const launchResult = await launch();
-  if (!("context" in launchResult)) throw new Error("Expected browser launch");
+  if (isElectron(launchResult)) throw new Error("Expected browser launch");
 
   const page =
-    "page" in launchResult
+    isPersistent(launchResult)
       ? launchResult.page
       : await launchResult.context.newPage();
 
@@ -105,6 +112,15 @@ type LaunchOptions =
       kind: "electron";
       executablePath: string;
     };
+
+type ElectronFlowLaunchOptions = {
+  executablePath: string;
+};
+
+type LaunchResult =
+  | AnonymousLaunchResult
+  | PersistentLaunchResult
+  | ElectronLaunchResult;
 ```
 
 QA Wolf maps `browserContext: "persistent"` to Playwright's persistent context mode. Pass `userDataDir` with `browserContext: "persistent"` when a profile directory should be reused.
@@ -118,17 +134,10 @@ export default flow(
   "Open with persistent profile",
   "Web - Chrome",
   async () => {
-    const launchResult = await launch({
+    const { page } = await launch({
       browserContext: "persistent",
       userDataDir: "/tmp/qawolf-profile",
     });
-    if (!("context" in launchResult))
-      throw new Error("Expected browser launch");
-
-    const page =
-      "page" in launchResult
-        ? launchResult.page
-        : await launchResult.context.newPage();
 
     await page.goto("https://example.com");
   },
@@ -138,17 +147,32 @@ export default flow(
 Electron example:
 
 ```ts
-import { flow, launch } from "@qawolf/flows/web";
+import { flow } from "@qawolf/flows/web";
 
-export default flow("Open Electron app", "Web - Chrome", async () => {
-  const { firstWindowPage } = await launch({
-    kind: "electron",
-    executablePath: "/Applications/MyApp.app/Contents/MacOS/MyApp",
-  });
-
-  await firstWindowPage.goto("about:blank");
-});
+export default flow(
+  "Open Electron app",
+  {
+    target: "Electron",
+    launch: {
+      executablePath: "/Applications/MyApp.app/Contents/MacOS/MyApp",
+    },
+  },
+  async ({ page }) => {
+    await page.goto("about:blank");
+  },
+);
 ```
+
+Manual `launch(...)` calls are different because they are not target-typed. Include `kind: "electron"` there and use `firstWindowPage` from the result.
+
+Static launch options infer a narrow return type when they determine the result shape:
+
+- `launch({ browserContext: "persistent" })` returns `PersistentLaunchResult`
+- `launch({ browserContext: "incognito" })` returns `AnonymousLaunchResult`
+- `launch({ kind: "electron", executablePath })` returns `ElectronLaunchResult`
+- `launch()` returns the full `LaunchResult` union because startup depends on the active flow target
+
+Use `isAnonymous(...)`, `isPersistent(...)`, and `isElectron(...)` to narrow dynamic results before reading shape-specific fields.
 
 ## Flow Callback Context
 
@@ -176,22 +200,23 @@ Electron launch-enabled flows receive the first Electron window as `page`.
 - default `browserContext` is `"incognito"`
 - default `browser` comes from the flow target
 - GPU launch behavior is derived from the flow target
+- Electron declarative launch requires `target: "Electron"` and `executablePath`
 
 Example:
 
 ```ts
-import { flow, launch } from "@qawolf/flows/web";
+import { flow, isElectron, isPersistent, launch } from "@qawolf/flows/web";
 
 export default flow(
   "Use target browser defaults",
   "Web - Firefox",
   async () => {
     const launchResult = await launch();
-    if (!("context" in launchResult))
+    if (isElectron(launchResult))
       throw new Error("Expected browser launch");
 
     const page =
-      "page" in launchResult
+      isPersistent(launchResult)
         ? launchResult.page
         : await launchResult.context.newPage();
 

--- a/qawolf/libraries/flows/core-concepts/flow-model.mdx
+++ b/qawolf/libraries/flows/core-concepts/flow-model.mdx
@@ -63,7 +63,8 @@ The callback receives the launched object for that platform:
 
 | Entry point | Launch object |
 | --- | --- |
-| `@qawolf/flows/web` | `page`, `context`, optional `browser` |
+| `@qawolf/flows/web` browser target | `page`, `context`, optional `browser` |
+| `@qawolf/flows/web` Electron target | `page` |
 | `@qawolf/flows/android` | `driver` |
 | `@qawolf/flows/ios` | `driver` |
 
@@ -94,23 +95,21 @@ Use this shape when the startup options are known before the callback runs.
 Pass the target directly and call `launch(...)` inside the callback only when startup depends on callback logic.
 
 ```ts
-import { flow, launch } from "@qawolf/flows/web";
+import { flow, isElectron, isPersistent, launch } from "@qawolf/flows/web";
 
 export default flow("Checkout", "Web - Chrome", async () => {
   const usePersistentProfile = process.env["USE_PROFILE"] === "true";
 
-  const launchResult = await launch(
-    usePersistentProfile
-      ? {
-          browserContext: "persistent",
-          userDataDir: "/tmp/qawolf-profile",
-        }
-      : undefined,
-  );
-  if (!("context" in launchResult)) throw new Error("Expected browser launch");
+  const launchResult = usePersistentProfile
+    ? await launch({
+        browserContext: "persistent",
+        userDataDir: "/tmp/qawolf-profile",
+      })
+    : await launch();
+  if (isElectron(launchResult)) throw new Error("Expected browser launch");
 
   const page =
-    "page" in launchResult
+    isPersistent(launchResult)
       ? launchResult.page
       : await launchResult.context.newPage();
 

--- a/qawolf/libraries/flows/core-concepts/runtime-and-launch.mdx
+++ b/qawolf/libraries/flows/core-concepts/runtime-and-launch.mdx
@@ -70,6 +70,8 @@ export default flow(
 Use launch-enabled flow definitions by default:
 
 ```ts
+import { flow } from "@qawolf/flows/web";
+
 export default flow(
   "Default startup",
   { target: "Web - Chrome", launch: true },
@@ -82,6 +84,8 @@ export default flow(
 Pass an options object to `launch` when startup options are known up front:
 
 ```ts
+import { flow } from "@qawolf/flows/web";
+
 export default flow(
   "Persistent profile",
   {
@@ -100,21 +104,21 @@ export default flow(
 Use `launch(...)` manually only when startup depends on callback logic:
 
 ```ts
+import { flow, isElectron, isPersistent, launch } from "@qawolf/flows/web";
+
 export default flow("Manual startup", "Web - Chrome", async () => {
   const useSavedProfile = process.env["USE_SAVED_PROFILE"] === "true";
 
-  const launchResult = await launch(
-    useSavedProfile
-      ? {
-          browserContext: "persistent",
-          userDataDir: "/tmp/profile",
-        }
-      : undefined,
-  );
-  if (!("context" in launchResult)) throw new Error("Expected browser launch");
+  const launchResult = useSavedProfile
+    ? await launch({
+        browserContext: "persistent",
+        userDataDir: "/tmp/profile",
+      })
+    : await launch();
+  if (isElectron(launchResult)) throw new Error("Expected browser launch");
 
   const page =
-    "page" in launchResult
+    isPersistent(launchResult)
       ? launchResult.page
       : await launchResult.context.newPage();
 

--- a/qawolf/libraries/flows/core-concepts/targets.mdx
+++ b/qawolf/libraries/flows/core-concepts/targets.mdx
@@ -12,6 +12,10 @@ A target tells QA Wolf where a flow should run.
 "Web - Chrome";
 ```
 
+```ts Electron
+"Electron";
+```
+
 ```ts Android
 "Android - Pixel";
 ```
@@ -32,7 +36,7 @@ Targets are grouped by the platform entry point you import from.
 
 | Entry point | Target family | Common target example |
 | --- | --- | --- |
-| `@qawolf/flows/web` | `Web - ...` | `Web - Chrome` |
+| `@qawolf/flows/web` | `Web - ...`, `Electron` | `Web - Chrome` |
 | `@qawolf/flows/android` | `Android - ...` | `Android - Pixel` |
 | `@qawolf/flows/ios` | `iOS - ...` | `iOS - iPhone 15 (iOS 26)` |
 | `@qawolf/flows/cli` | `Basic` | `Basic` |
@@ -44,14 +48,14 @@ Use the API reference when you need the full current literal list: [Target Liter
 Use a target string when the callback will launch manually or when the platform does not have a launch model.
 
 ```ts
-import { flow, launch } from "@qawolf/flows/web";
+import { flow, isElectron, isPersistent, launch } from "@qawolf/flows/web";
 
 export default flow("Manual launch", "Web - Chrome", async () => {
   const launchResult = await launch();
-  if (!("context" in launchResult)) throw new Error("Expected browser launch");
+  if (isElectron(launchResult)) throw new Error("Expected browser launch");
 
   const page =
-    "page" in launchResult
+    isPersistent(launchResult)
       ? launchResult.page
       : await launchResult.context.newPage();
 

--- a/qawolf/libraries/flows/get-started.mdx
+++ b/qawolf/libraries/flows/get-started.mdx
@@ -102,7 +102,8 @@ When `launch` is enabled, the callback also receives platform runtime objects:
 
 | Platform | Additional callback parameters |
 | --- | --- |
-| Web | `page`, `context`, optional `browser` |
+| Web browser | `page`, `context`, optional `browser` |
+| Web Electron | `page` |
 | Android | `driver` |
 | iOS | `driver` |
 
@@ -135,23 +136,21 @@ This keeps startup declarative while still giving the callback a ready-to-use `p
 Pass the target directly and call `launch(...)` in the callback only when the flow must decide startup at runtime.
 
 ```ts
-import { flow, launch } from "@qawolf/flows/web";
+import { flow, isElectron, isPersistent, launch } from "@qawolf/flows/web";
 
 export default flow("Open account", "Web - Chrome", async () => {
   const useSavedProfile = process.env["USE_SAVED_PROFILE"] === "true";
 
-  const launchResult = await launch(
-    useSavedProfile
-      ? {
-          browserContext: "persistent",
-          userDataDir: "/tmp/qawolf-profile",
-        }
-      : undefined,
-  );
-  if (!("context" in launchResult)) throw new Error("Expected browser launch");
+  const launchResult = useSavedProfile
+    ? await launch({
+        browserContext: "persistent",
+        userDataDir: "/tmp/qawolf-profile",
+      })
+    : await launch();
+  if (isElectron(launchResult)) throw new Error("Expected browser launch");
 
   const page =
-    "page" in launchResult
+    isPersistent(launchResult)
       ? launchResult.page
       : await launchResult.context.newPage();
 

--- a/qawolf/libraries/flows/how-to/launch-electron.mdx
+++ b/qawolf/libraries/flows/how-to/launch-electron.mdx
@@ -4,7 +4,7 @@ description: "Launch an Electron app from a web flow."
 sidebarTitle: "Launch Electron"
 ---
 
-Use Electron launch mode when the target is a desktop app instead of a browser page.
+Use the `Electron` target when the flow starts a desktop app instead of a browser page.
 
 ```ts
 import { flow } from "@qawolf/flows/web";
@@ -12,9 +12,8 @@ import { flow } from "@qawolf/flows/web";
 export default flow(
   "Open desktop app",
   {
-    target: "Web - Chrome",
+    target: "Electron",
     launch: {
-      kind: "electron",
       executablePath: "/Applications/MyApp.app/Contents/MacOS/MyApp",
     },
   },
@@ -24,7 +23,7 @@ export default flow(
 );
 ```
 
-For the exact Electron launch shape, see the [Web Reference](/qawolf/libraries/flows/api-reference/web).
+Declarative Electron launch options omit `kind` because the target already identifies the flow as Electron. For the exact Electron launch shape, see the [Web Reference](/qawolf/libraries/flows/api-reference/web).
 
 ## Use The First Window
 
@@ -37,7 +36,7 @@ await page.getByRole("button", { name: "Continue" }).click();
 
 ## Choose The Executable At Runtime
 
-Call `launch(...)` manually when the app path depends on callback logic.
+Call `launch(...)` manually when the app path depends on callback logic. Manual launch calls must include `kind: "electron"` because they are not typed by the flow target.
 
 ```ts
 import { flow, launch } from "@qawolf/flows/web";

--- a/qawolf/libraries/flows/how-to/write-a-web-flow.mdx
+++ b/qawolf/libraries/flows/how-to/write-a-web-flow.mdx
@@ -90,23 +90,21 @@ For every browser and Electron launch field, see the [Web Reference](/qawolf/lib
 Call `launch()` yourself only when startup depends on callback logic.
 
 ```ts
-import { flow, launch } from "@qawolf/flows/web";
+import { flow, isElectron, isPersistent, launch } from "@qawolf/flows/web";
 
 export default flow("Open account", "Web - Chrome", async () => {
   const useSavedProfile = process.env["USE_SAVED_PROFILE"] === "true";
 
-  const launchResult = await launch(
-    useSavedProfile
-      ? {
-          browserContext: "persistent",
-          userDataDir: "/tmp/qawolf-profile",
-        }
-      : undefined,
-  );
-  if (!("context" in launchResult)) throw new Error("Expected browser launch");
+  const launchResult = useSavedProfile
+    ? await launch({
+        browserContext: "persistent",
+        userDataDir: "/tmp/qawolf-profile",
+      })
+    : await launch();
+  if (isElectron(launchResult)) throw new Error("Expected browser launch");
 
   const page =
-    "page" in launchResult
+    isPersistent(launchResult)
       ? launchResult.page
       : await launchResult.context.newPage();
 
@@ -116,7 +114,7 @@ export default flow("Open account", "Web - Chrome", async () => {
 
 ## Launch Electron
 
-Use the Electron launch kind when the target is an app instead of a website.
+Use the `Electron` target when the target is an app instead of a website.
 
 ```ts
 import { flow } from "@qawolf/flows/web";
@@ -124,9 +122,8 @@ import { flow } from "@qawolf/flows/web";
 export default flow(
   "Open desktop app",
   {
-    target: "Web - Chrome",
+    target: "Electron",
     launch: {
-      kind: "electron",
       executablePath: "/Applications/MyApp.app/Contents/MacOS/MyApp",
     },
   },
@@ -136,7 +133,7 @@ export default flow(
 );
 ```
 
-The Electron callback receives the first window as `page`.
+The Electron callback receives the first window as `page`. Declarative Electron launch options omit `kind` because the target already identifies Electron.
 
 ## Assertions
 

--- a/qawolf/mobile-native-media.mdx
+++ b/qawolf/mobile-native-media.mdx
@@ -1,0 +1,33 @@
+---
+title: "Mobile-Native Media"
+description: "Inject and capture media in mobile test flows."
+icon: "tablet-smartphone"
+---
+
+Use these guides when a native mobile flow needs app media, device camera input, audio, video, or scannable codes.
+
+<CardGroup cols={2}>
+  <Card title="Photo Library Management" icon="image" href="/qawolf/photo-library-management">
+    Add, select, and manage photos during mobile test flows.
+  </Card>
+
+  <Card title="Camera Injection" icon="camera" href="/qawolf/camera-and-audio-injection">
+    Inject camera feeds for flows that depend on live camera input.
+  </Card>
+
+  <Card title="Barcode Injection" icon="scan-qr-code" href="/qawolf/barcode-qrcode-scanning">
+    Test barcode and QR code scanning workflows.
+  </Card>
+
+  <Card title="Audio Injection" icon="mic" href="/qawolf/audio-injection">
+    Provide audio input to mobile apps during a flow.
+  </Card>
+
+  <Card title="Audio Capture" icon="audio-waveform" href="/qawolf/audio-capture">
+    Capture and inspect audio produced during a flow.
+  </Card>
+
+  <Card title="Video Injection" icon="video" href="/qawolf/video-injection">
+    Inject video into mobile flows that depend on camera or media input.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Overview

Updates the flow docs to match the latest `@qawolf/flows/web` API changes from platform PR 25040.

## Changes

- Document declarative Electron flows with `target: "Electron"` and `launch: { executablePath }`.
- Clarify that manual Electron `launch(...)` calls still require `kind: "electron"` and return `firstWindowPage`.
- Add the web launch result guards `isAnonymous`, `isPersistent`, and `isElectron` to the API reference.
- Replace structural launch result checks in examples with the public narrowing helpers.
- Document static launch result narrowing for persistent, incognito, and Electron launch options.

## Validation

- `git diff --check HEAD~1..HEAD`
- `npx mint@latest validate`
