### PR TITLE
Document emails API client transport

### DIFF
--- a/qawolf/libraries/emails/api-reference/client.mdx
+++ b/qawolf/libraries/emails/api-reference/client.mdx
@@ -18,18 +18,72 @@ Example:
 import { configureEmailsClient, createEmailsClient } from "@qawolf/emails";
 
 const client = await createEmailsClient({
-  emailerUrl: "https://emailer.example.com",
+  apiKey: process.env["QAWOLF_API_KEY"]!,
   pollForEmailsDefaultTimeoutMs: 30_000,
   teamId: "team_123",
+  url: "https://app.qawolf.com/api",
   waitForMessagesDefaultDelayMs: 1_000,
 });
 
 configureEmailsClient(client);
 ```
 
+## `EmailsClientOptions`
+
+`createEmailsClient(...)` accepts one of two transport configurations.
+
+Use the QA Wolf API configuration for new code:
+
+```ts
+const client = await createEmailsClient({
+  apiKey: process.env["QAWOLF_API_KEY"]!,
+  pollForEmailsDefaultTimeoutMs: 30_000,
+  teamId: "team_123",
+  url: "https://app.qawolf.com/api",
+  waitForMessagesDefaultDelayMs: 1_000,
+});
+```
+
+The client also supports an internal runner configuration:
+
+```ts
+const client = await createEmailsClient({
+  emailerUrl: process.env["EMAILER_URL"]!,
+  pollForEmailsDefaultTimeoutMs: 30_000,
+  teamId: "team_123",
+  waitForMessagesDefaultDelayMs: 1_000,
+});
+```
+
+Do not pass both configurations at the same time. If you use `apiKey` and
+`url`, do not pass `emailerUrl`.
+
+```ts
+type EmailsClientOptions =
+  | {
+      apiKey: string;
+      emailerUrl?: never;
+      logger?: (severity: string, message: string) => void;
+      pollForEmailsDefaultTimeoutMs: number;
+      teamId?: string;
+      url: string;
+      waitForMessagesDefaultDelayMs: number;
+    }
+  | {
+      apiKey?: never;
+      emailerUrl: string;
+      logger?: (severity: string, message: string) => void;
+      pollForEmailsDefaultTimeoutMs: number;
+      teamId?: string;
+      url?: never;
+      waitForMessagesDefaultDelayMs: number;
+    };
+```
+
 ## Role Of `createEmailsClient(...)`
 
-This creates a service-backed client that can be used directly by runners, tooling, or any environment that has access to the QA Wolf email service.
+This creates a service-backed client that can be used directly by local
+harnesses, tooling, or other runtime environments.
 
 Example:
 
@@ -37,12 +91,13 @@ Example:
 import { createEmailsClient } from "@qawolf/emails";
 
 const client = await createEmailsClient({
-  emailerUrl: "https://emailer.example.com",
+  apiKey: process.env["QAWOLF_API_KEY"]!,
   logger: (severity, message) => {
     console.log(severity, message);
   },
   pollForEmailsDefaultTimeoutMs: 30_000,
   teamId: "team_123",
+  url: "https://app.qawolf.com/api",
   waitForMessagesDefaultDelayMs: 1_000,
 });
 
@@ -51,7 +106,9 @@ const inbox = await client.getInbox({ new: true });
 
 ## Compatibility Note
 
-`buildGetInboxFn(...)` remains useful for compatibility with runtimes that still inject `getInbox` directly, but new runtime code should prefer `createEmailsClient(...)`.
+`buildGetInboxFn(...)` remains useful for compatibility with runtimes that still
+inject `getInbox` directly, but new runtime code should prefer
+`createEmailsClient(...)`.
 
 Example:
 
@@ -59,9 +116,10 @@ Example:
 import { buildGetInboxFn } from "@qawolf/emails";
 
 const getInbox = await buildGetInboxFn({
-  emailerUrl: "https://emailer.example.com",
+  apiKey: process.env["QAWOLF_API_KEY"]!,
   pollForEmailsDefaultTimeoutMs: 30_000,
   teamId: "team_123",
+  url: "https://app.qawolf.com/api",
   waitForMessagesDefaultDelayMs: 1_000,
 });
 

--- a/qawolf/libraries/emails/get-started.mdx
+++ b/qawolf/libraries/emails/get-started.mdx
@@ -67,15 +67,16 @@ This prevents the flow from reading a message that arrived earlier.
 ## Runtime Setup
 
 In normal QA Wolf runs, the runner configures the email client. Local harnesses
-can configure it explicitly.
+can configure it explicitly with the QA Wolf API.
 
 ```ts
 import { configureEmailsClient, createEmailsClient } from "@qawolf/emails";
 
 const client = await createEmailsClient({
-  emailerUrl: process.env["EMAILER_URL"]!,
+  apiKey: process.env["QAWOLF_API_KEY"]!,
   pollForEmailsDefaultTimeoutMs: 300_000,
   teamId: process.env["QAWOLF_TEAM_ID"],
+  url: process.env["QAWOLF_API_URL"]!,
   waitForMessagesDefaultDelayMs: 15_000,
 });
 

--- a/qawolf/libraries/emails/how-to/configure-the-runtime-client.mdx
+++ b/qawolf/libraries/emails/how-to/configure-the-runtime-client.mdx
@@ -12,17 +12,30 @@ Runners and local execution environments create the client first:
 import { configureEmailsClient, createEmailsClient } from "@qawolf/emails";
 
 const emails = await createEmailsClient({
-  emailerUrl: process.env["EMAILER_URL"],
+  apiKey: process.env["QAWOLF_API_KEY"]!,
   logger(severity, message) {
     console.log(severity, message);
   },
   pollForEmailsDefaultTimeoutMs: 300_000,
   teamId: process.env["QAWOLF_TEAM_ID"],
+  url: process.env["QAWOLF_API_URL"]!,
   waitForMessagesDefaultDelayMs: 15_000,
 });
 
 configureEmailsClient(emails);
 ```
+
+## Runtime Values
+
+The recommended client setup needs:
+
+- `QAWOLF_API_URL`: QA Wolf API URL, ending in `/api`.
+- `QAWOLF_API_KEY`: API key used to authenticate requests.
+- `QAWOLF_TEAM_ID`: workspace/team ID used as `teamId`.
+
+QA Wolf-hosted runners configure email access automatically. Internal runners
+may still use `EMAILER_URL`, but new local harnesses and runtime integrations
+should prefer `QAWOLF_API_URL` with `QAWOLF_API_KEY`.
 
 ## Test Cleanup
 


### PR DESCRIPTION
## Summary

Document the `@qawolf/emails` client configuration that uses the QA Wolf API URL and API key.

## Changes

- Update emails client examples to prefer `QAWOLF_API_URL` + `QAWOLF_API_KEY`.
- Document the mutually exclusive `EmailsClientOptions` shapes.
- Keep the internal `EMAILER_URL` runner transport as a compatibility note rather than the primary setup path.

## Testing

- Not run; docs-only change.
