### PR TITLE
docs(flows): QA Wolf docs incorrectly refer to `input` instead of `inputs`

### DIFF
--- a/qawolf/libraries/flows/api-reference/android.mdx
+++ b/qawolf/libraries/flows/api-reference/android.mdx
@@ -38,7 +38,7 @@ export default flow(
 
 All Android flow callbacks receive:
 
-- `input`
+- `inputs`
 - `setOutput(...)`
 - `test(...)`
 
@@ -98,7 +98,7 @@ Use `flow(...)` for Android authoring.
 
 Behavior from the implementation:
 
-- without launch, the callback receives `input`, `setOutput(...)`, and `test(...)`
+- without launch, the callback receives `inputs`, `setOutput(...)`, and `test(...)`
 - with `launch: true`, the flow calls `launch()` with default Android startup
 - with `launch: <options>`, the flow calls `launch(options)`
 - when launch is enabled, the callback also receives `driver`

--- a/qawolf/libraries/flows/api-reference/cli.mdx
+++ b/qawolf/libraries/flows/api-reference/cli.mdx
@@ -22,11 +22,11 @@ import { flow } from "@qawolf/flows/cli";
 export default flow(
   "Prepare release metadata",
   "Basic",
-  async ({ input, setOutput, test }) => {
+  async ({ inputs, setOutput, test }) => {
     await test("create release payload", async () => {
       setOutput("release", {
         generatedAt: new Date().toISOString(),
-        input,
+        inputs,
         status: "ready",
       });
     });
@@ -68,7 +68,7 @@ The callback receives the CLI flow context.
 
 Public callback parameters:
 
-- `input`
+- `inputs`
 - `setOutput(...)`
 - `test(...)`
 
@@ -82,11 +82,11 @@ import { flow } from "@qawolf/flows/cli";
 export default flow(
   "Prepare release metadata",
   "Basic",
-  async ({ input, setOutput, test }) => {
+  async ({ inputs, setOutput, test }) => {
     await test("create release payload", async () => {
       setOutput("release", {
         generatedAt: new Date().toISOString(),
-        input,
+        inputs,
         status: "ready",
       });
     });

--- a/qawolf/libraries/flows/api-reference/ios.mdx
+++ b/qawolf/libraries/flows/api-reference/ios.mdx
@@ -40,7 +40,7 @@ export default flow(
 
 All iOS flow callbacks receive:
 
-- `input`
+- `inputs`
 - `setOutput(...)`
 - `test(...)`
 
@@ -100,7 +100,7 @@ Use `flow(...)` for iOS authoring.
 
 Behavior from the implementation:
 
-- without launch, the callback receives `input`, `setOutput(...)`, and `test(...)`
+- without launch, the callback receives `inputs`, `setOutput(...)`, and `test(...)`
 - with `launch: true`, the flow calls `launch()` with default iOS startup
 - with `launch: <options>`, the flow calls `launch(options)`
 - when launch is enabled, the callback also receives `driver`

--- a/qawolf/libraries/flows/api-reference/web.mdx
+++ b/qawolf/libraries/flows/api-reference/web.mdx
@@ -178,7 +178,7 @@ Use `isAnonymous(...)`, `isPersistent(...)`, and `isElectron(...)` to narrow dyn
 
 All web flow callbacks receive:
 
-- `input`
+- `inputs`
 - `setOutput(...)`
 - `test(...)`
 

--- a/qawolf/libraries/flows/core-concepts/flow-model.mdx
+++ b/qawolf/libraries/flows/core-concepts/flow-model.mdx
@@ -20,7 +20,7 @@ flow("Name shown in QA Wolf", target, async (runtime) => {
 
 Every flow callback can receive:
 
-- `input` for values passed into the flow
+- `inputs` for values passed into the flow
 - `setOutput(...)` for values a later flow can read
 - `test(...)` for named sub-steps
 
@@ -30,10 +30,10 @@ import { flow } from "@qawolf/flows/cli";
 export default flow(
   "Prepare account fixture",
   "Basic",
-  async ({ input, setOutput, test }) => {
+  async ({ inputs, setOutput, test }) => {
     await test("publish account fixture", async () => {
       setOutput("account", {
-        input,
+        inputs,
         role: "admin",
       });
     });

--- a/qawolf/libraries/flows/get-started.mdx
+++ b/qawolf/libraries/flows/get-started.mdx
@@ -96,7 +96,7 @@ export default flow(
 
 </CodeGroup>
 
-Every flow callback can receive `input`, `setOutput(...)`, and `test(...)`.
+Every flow callback can receive `inputs`, `setOutput(...)`, and `test(...)`.
 
 When `launch` is enabled, the callback also receives platform runtime objects:
 

--- a/qawolf/libraries/flows/how-to/write-a-cli-flow.mdx
+++ b/qawolf/libraries/flows/how-to/write-a-cli-flow.mdx
@@ -24,14 +24,14 @@ CLI flows currently support one target.
 <CodeGroup>
 
 ```ts String target
-export default flow("CLI task", "Basic", async ({ input }) => {
-  console.log(input);
+export default flow("CLI task", "Basic", async ({ inputs }) => {
+  console.log(inputs);
 });
 ```
 
 ```ts Object target
-export default flow("CLI task", { target: "Basic" }, async ({ input }) => {
-  console.log(input);
+export default flow("CLI task", { target: "Basic" }, async ({ inputs }) => {
+  console.log(inputs);
 });
 ```
 
@@ -51,16 +51,16 @@ export default flow("Write report", "Basic", async () => {
 
 ## Pass Data To Later Flows
 
-Use `input` for values passed into the flow and `setOutput(...)` for values a later flow can read.
+Use `inputs` for values passed into the flow and `setOutput(...)` for values a later flow can read.
 
 ```ts
 export default flow(
   "Prepare account fixture",
   "Basic",
-  async ({ input, setOutput, test }) => {
+  async ({ inputs, setOutput, test }) => {
     await test("publish account fixture", async () => {
       setOutput("account", {
-        input,
+        inputs,
         role: "admin",
       });
     });
@@ -68,6 +68,6 @@ export default flow(
 );
 ```
 
-Use CLI flows for setup, teardown, notifications, and other non-UI work. Reach for `input`, `setOutput(...)`, and `test(...)` when you need QA Wolf runtime state.
+Use CLI flows for setup, teardown, notifications, and other non-UI work. Reach for `inputs`, `setOutput(...)`, and `test(...)` when you need QA Wolf runtime state.
 
 For the exact CLI target and callback context shape, see the [CLI Reference](/qawolf/libraries/flows/api-reference/cli).


### PR DESCRIPTION
## Overview of Problem

- The flows library docs reference `input` as the callback parameter name, but the runtime defines it as `inputs`.

## Overview of Changes

- [x] Update flows library docs (web, Android, iOS, CLI, get-started, flow-model) to destructure `inputs` for the callback parameter.