### PR TITLE
MKTG-5469

### DIFF
--- a/qawolf/Use-emails-in-tests-29c5b2a994fb81cf8a03de3eb25ed68e.mdx
+++ b/qawolf/Use-emails-in-tests-29c5b2a994fb81cf8a03de3eb25ed68e.mdx
@@ -1,54 +1,137 @@
 ---
 title: "Test a feature that sends or receives emails"
-description: "Use mail.inbox() from @qawolf/emails to send, receive, and verify emails during your QA Wolf test flows."
+description: "Use mail.inbox() from @qawolf/emails to send, receive, and verify emails during your QA Wolf flows."
 sidebarTitle: "Use emails in tests"
 icon: "mail"
 ---
 
-## Accessing `mail` in your flow
+<Info>
+  Any email address used in a flow must be on your team's [Email Allowlist](#the-email-allowlist).
+</Info>
 
-Import `mail` from `@qawolf/emails` at the top of your flow file. Runners configure the email client automatically; no additional setup is required.
+## Examples
+
+**Verify a signup confirmation or magic link**
+
+Use a fresh inbox and fill it into your app's email field. Wait for the message after the triggering action.
 
 ```javascript
-import { flow } from "@qawolf/flows/web";
-import { mail } from "@qawolf/emails";
+const inbox = await mail.inbox({ new: true });
 
-export default flow(
-  "My Flow",
-  { target: "Web - Chrome", launch: true },
-  async ({ page }) => {
-    const inbox = await mail.inbox();
-  },
-);
+await page.getByLabel("Email").fill(inbox.emailAddress);
+
+const after = new Date();
+await page.getByRole("button", { name: "Send magic link" }).click();
+
+const message = await inbox.waitForMessage({ after });
+await expect(message.urls[0]).toContain("/activate");
 ```
 
-## Email addresses and inboxes
+**Extract a login code from email**
 
-When your app sends confirmation links, password resets, or invitation emails, you can test those flows directly inside QA Wolf using `mail.inbox()`.
+Use `after` immediately before the action that sends the code to avoid matching an older message from the same address.
 
-`mail.inbox()` gives you an email inbox you can send to, wait on, and read from — all inside your test runner. It can also generate **unique email addresses**, so every test run uses a fresh inbox.
+```javascript
+const inbox = await mail.inbox({ new: true });
 
-In addition, it includes helper functions to:
+await page.getByLabel("Email").fill(inbox.emailAddress);
 
-- **Send messages** from that address
-- Wait for one message to arrive
-- Wait for multiple messages over a period of time
+const after = new Date();
+await page.getByRole("button", { name: "Send code" }).click();
 
-<Tip>
-  `mail.inbox()` returns the following object: `{ emailAddress, sendMessage, waitForMessage, waitForMessages }`.
-</Tip>
+const message = await inbox.waitForMessage({ after });
+const match = message.text.match(/\b\d{6}\b/);
+
+if (!match) throw new Error("Login code email did not contain a 6-digit code");
+
+await page.getByLabel("Code").fill(match[0]);
+await page.getByRole("button", { name: "Verify" }).click();
+```
+
+**Wait for a batch of emails**
+
+Use `waitForMessages` when one action should trigger several emails, such as a team invite or multi-step onboarding sequence. Use `delay` if your app enqueues email work in the background.
+
+```javascript
+const inbox = await mail.inbox({ new: true });
+
+const after = new Date();
+await page.getByRole("button", { name: "Invite team" }).click();
+
+const messages = await inbox.waitForMessages({
+  after,
+  minCount: 3,
+  timeout: 120_000,
+  delay: 5_000,
+});
+
+const subjects = messages.map((m) => m.subject);
+expect(subjects).toContain("Welcome");
+expect(subjects).toContain("Your workspace is ready");
+```
+
+**Simulate an inbound email**
+
+Use `sendMessage` when your app receives or reacts to incoming email — for example, a support reply or an automated trigger.
+
+```javascript
+const inbox = await mail.inbox({ new: true });
+
+await inbox.sendMessage({
+  to: ["support@example.com"],
+  subject: "Need help",
+  text: "The test user is asking for support.",
+});
+```
+
+**Send with attachments**
+
+Pass an `attachments` array to `sendMessage`. Use `contentId` when the HTML body references an inline file.
+
+```javascript
+await inbox.sendMessage({
+  to: ["invoices@example.com"],
+  subject: "Invoice",
+  text: "Attached.",
+  attachments: [
+    {
+      fileName: "invoice.txt",
+      content: Buffer.from("invoice total: $10.00"),
+      type: "text/plain",
+    },
+  ],
+});
+```
+
+**Reply to an app email**
+
+```javascript
+const original = await inbox.waitForMessage({});
+
+await inbox.sendMessage({
+  to: [original.from],
+  subject: `Re: ${original.subject}`,
+  text: "Thanks, this worked.",
+});
+```
+
+## When to use
+
+- Your app sends a confirmation, magic link, or verification code by email
+- Your app sends a batch of emails when a user action occurs
+- Your app receives or reacts to inbound email
+- You need a fresh, isolated inbox for every test run
+- Your app processes email replies or attachments
 
 ## The Email Allowlist
 
-Our platform includes an **Email Allowlist** to ensure test emails are delivered only to approved addresses or domains. The allowlist prevents unintended delivery and keeps your testing environments secure and controlled. You must add any email address you use in a flow to the allowlist.
+QA Wolf includes an **Email Allowlist** to ensure test emails are delivered only to approved addresses or domains. You must add any email address used in a flow to the allowlist before running the flow.
 
-QA Wolf provides internal email domains—**qawolf.email** and **qawolfworkflows.com**—for email testing. We recommend using these instead of public email services because we control the servers, which allows us to stabilize tests that rely on email interactions and prevent the sporadic failures that can occur when using external providers.
+QA Wolf provides internal email domains — **qawolf.email** and **qawolfworkflows.com** — for email testing. These are recommended over public email services because QA Wolf controls the servers, which stabilizes tests that rely on email interactions.
 
-Our platform sets an automatic default. You cannot delete the default.
+The platform sets an automatic default address. You cannot delete the default.
 
-## Change the default email
-
-When you set a default email address, any test or helper that accepts an email can omit the address and will fall back to the default. You can still override per test by specifying a different address.
+**To add or change the default email address:**
 
 <Steps>
   <Step>
@@ -62,7 +145,7 @@ When you set a default email address, any test or helper that accepts an email c
 
     a. You can create as many email addresses as you like in the allowlist.
 
-    b. To change the default email address in the allowlist, hover over the email you'd like to set as the default, then click the <Icon icon="ellipsis" /> icon and select Make default.
+    b. To change the default, hover over the address you want to set as default, click the <Icon icon="ellipsis" /> icon, and select **Make default**.
 
     <Frame>
       ![](/images/advanced-flows-and-tests/image-3.png)
@@ -70,83 +153,66 @@ When you set a default email address, any test or helper that accepts an email c
   </Step>
 </Steps>
 
-## Get the contents of an email inbox
+## Address options
 
-The simplest way to access your test inbox is to add this line to your flow:
+**Use a fresh address for each run**
+
+Pass `new: true` to generate a unique derived address. This is the right choice for most tests — it isolates each run so old emails from previous runs are never matched.
 
 ```javascript
-const { emailAddress } = await mail.inbox();
+const inbox = await mail.inbox({ new: true });
+// Example: my-team+a25sa5q@qawolf.email
 ```
 
-If you don't pass any options to `mail.inbox`, QA Wolf uses your **team's default email address**, which you can find by going to the **Flows** tab, selecting **Workspace settings** from the `Workspace name` dropdown, choosing Flows from the left navigation, and finding the email address marked as **default** under the **Email Allowlist**.
-
-<Tip>
-  Any email address used with `mail.inbox` must be on your team's [Email Allowlist](/qawolf/Use-emails-in-tests-29c5b2a994fb81cf8a03de3eb25ed68e#the-email-allowlist).
-</Tip>
-
-If you need to access a specific allowlisted email address:
+If your app does not accept `+` addressing, use a custom delimiter:
 
 ```javascript
-const { emailAddress } = await mail.inbox({
+const inbox = await mail.inbox({ new: true, delimiter: "-" });
+```
+
+**Use the workspace default**
+
+Omit all options to use your team's default address. Use this only when a test intentionally shares a stable inbox.
+
+```javascript
+const inbox = await mail.inbox();
+```
+
+**Use a specific allowlisted address**
+
+```javascript
+const inbox = await mail.inbox({
   address: "my-team+admin@qawolf.email",
 });
 ```
 
-You can even include a display name by using the following format:
+## Full sample test
 
 ```javascript
-const { emailAddress } = await mail.inbox({
-  address: "Gerald TheSpider <my-team@qawolf.email>",
-});
-```
+import { flow } from "@qawolf/flows/web";
+import { mail } from "@qawolf/emails";
 
-If your test needs a brand-new inbox each run, set `new: true`.
+export default flow(
+  "Sign in with email code",
+  { target: "Web - Chrome", launch: true },
+  async ({ page }) => {
+    const inbox = await mail.inbox({ new: true });
 
-```javascript
-const { emailAddress } = await mail.inbox({ new: true });
-// Example: my-team+a25sa5q@qawolf.email
-```
+    await page.goto("https://example.com/login");
+    await page.getByLabel("Email").fill(inbox.emailAddress);
 
-QA Wolf automatically appends a random suffix after a + sign (i.e., plus addressing).
+    const after = new Date();
+    await page.getByRole("button", { name: "Send code" }).click();
 
-<Tip>
-  Your application may not allow + symbols in email addresses. If so, you can specify a different delimiter using the `delimiter` option.
+    const message = await inbox.waitForMessage({ after });
+    const match = message.text.match(/\b\d{6}\b/);
 
-  `const { emailAddress } = await mail.inbox({ new: true, delimiter: "-" });`
+    if (!match) throw new Error("Login code email did not contain a 6-digit code");
 
-  The above generates new emails with random strings after the - symbol.
-</Tip>
+    await page.getByLabel("Code").fill(match[0]);
+    await page.getByRole("button", { name: "Verify" }).click();
 
-## Wait for an email in a test
-
-Often, you want your test to wait for a specific email to arrive and then verify its content. This approach is ideal for verifying signup confirmations or password reset links.
-
-```javascript
-const { waitForMessage } = await mail.inbox({ new: true });
-
-const message = await waitForMessage({ subject: /Welcome to QA Wolf/ });
-await expect(message.body).toContain("This is a test email");
-```
-
-Sometimes, you want to collect all emails received over a short window. This approach helps validate bulk or sequence-based email events (like multi-step onboarding).
-
-```javascript
-const { waitForMessages } = await mail.inbox({ new: true });
-
-const messages = await waitForMessages({ wait: 10000 });
-console.log(`Received ${messages.length} messages`);
-```
-
-## Send an email from a test
-
-Our platform includes the `sendMessage` helper for the less common case where your application **receives** or **reacts to incoming emails**. You can use it to simulate an external sender and verify how your app processes inbound messages (like replies, support emails, or automated triggers).
-
-```javascript
-const { sendMessage } = await mail.inbox({ new: true });
-
-await sendMessage({
-  to: "my-team+recipient@qawolf.email",
-  subject: "Welcome to QA Wolf",
-  body: "This is a test email from QA Wolf.",
-});
+    await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+  },
+);
 ```

--- a/qawolf/libraries/emails/troubleshooting.mdx
+++ b/qawolf/libraries/emails/troubleshooting.mdx
@@ -27,3 +27,18 @@ Check:
 - the product under test actually sent the email
 - the address being used is allowed for the workspace
 - the timeout is long enough for the expected delivery path
+
+## Old emails are matched by waitForMessage
+
+Where possible, use `new: true` to generate a unique address for each run. This ensures `waitForMessage` only sees messages from the current run.
+
+If you must reuse a stable address, pass `after: new Date()` immediately before the action that triggers the email:
+
+```javascript
+const after = new Date();
+await page.getByRole("button", { name: "Send code" }).click();
+
+const message = await inbox.waitForMessage({ after });
+```
+
+If neither option is available and you are running a local harness, call `resetEmailsClient()` between test suites to clear the client state.


### PR DESCRIPTION
Duplicate Email content to Solutions recipe to prepare for deletion of How-to , Core concepts, and Get Started content  under library tab

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/qawolf/qawolf/editor/mktg-5469-dedupe-libraryemail?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->