### PR TITLE
[GEN-1903] Add docs to https://github.com/qawolf/docs for new APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "docs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "docs",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/qawolf/anatomy-of-a-qa-wolf-test-mobile-edition.mdx
+++ b/qawolf/anatomy-of-a-qa-wolf-test-mobile-edition.mdx
@@ -199,7 +199,7 @@ Launch-enabled flows also receive the platform object (`page`, `context`, `brows
 For the full callback context shape, see the API Reference for [Web](/qawolf/libraries/flows/api-reference/web#flow-callback-context), [Android](/qawolf/libraries/flows/api-reference/android#flow-callback-context), and [iOS](/qawolf/libraries/flows/api-reference/ios#flow-callback-context).
 
 <Note>
-  `launch()`, `expect`, `device`, and `platform.target` are stubs in the package code, and they are replaced by the runner at execution time. They only work while a flow is running inside the QA Wolf runner — keep them inside the flow callback, not at the module level. \
+  `launch()`, `device`, and `platform.target` are stubs in the package code, and they are replaced by the runner at execution time. They only work while a flow is running inside the QA Wolf runner — keep them inside the flow callback, not at the module level. \
   \
   Module-level code should be limited to imports, constants, and pure helper functions.
 </Note>

--- a/qawolf/libraries/flows/api-reference/android.mdx
+++ b/qawolf/libraries/flows/api-reference/android.mdx
@@ -262,7 +262,9 @@ export default flow("Set device location", "Android - Pixel", async () => {
 
 ## `expect`
 
-The exported `expect` value is a type-safe stub in package code and is replaced by the runner during execution.
+The exported `expect` is the assertion helper for Android flows, backed by [`expect-webdriverio`](https://webdriver.io/docs/api/expect-webdriverio). All WebdriverIO matchers are available — including auto-retrying element matchers like `toBeDisplayed`, `toExist`, `toHaveText`, and `toHaveAttribute`. See the [expect-webdriverio matchers reference](https://webdriver.io/docs/api/expect-webdriverio) for the full list.
+
+Always import `expect` from `@qawolf/flows/android` rather than from `expect-webdriverio` directly, so that QA Wolf's defaults (timeout, `toHaveScreenshot`) stay in effect.
 
 Example:
 
@@ -270,12 +272,16 @@ Example:
 import { expect, flow } from "@qawolf/flows/android";
 
 export default flow(
-  "Use runner expect",
+  "Verify welcome screen",
   { target: "Android - Pixel", launch: true },
   async ({ driver, test }) => {
-    await test("check driver", async () => {
-      await expect(driver).toBeDefined();
+    await test("welcome heading is visible", async () => {
+      const heading = driver.$("~welcome-heading");
+      await expect(heading).toBeDisplayed();
+      await expect(heading).toHaveText("Welcome");
     });
   },
 );
 ```
+
+For visual regression assertions with `expect(driver).toHaveScreenshot(...)`, see [Native mobile screenshots](/qawolf/visual-diffing-native-app).

--- a/qawolf/libraries/flows/api-reference/cli.mdx
+++ b/qawolf/libraries/flows/api-reference/cli.mdx
@@ -120,16 +120,21 @@ See [Passing data between flows](/qawolf/Pass-data-between-flows-29d5b2a994fb801
 
 ## `expect`
 
-Like the other platform entry points, the exported `expect` value is a type-safe stub in package code and is replaced by the runner when the flow executes.
+The exported `expect` is a re-export of the [`expect`](https://www.npmjs.com/package/expect) package — the same assertion library Jest uses. Use Jest's [`expect` reference](https://jestjs.io/docs/expect) for the full matcher list (`toBe`, `toEqual`, `toMatchObject`, `toThrow`, etc.).
+
+Always import `expect` from `@qawolf/flows/cli` rather than from `expect` or `jest` directly, so that future QA Wolf extensions stay in effect.
 
 Example:
 
 ```ts
 import { expect, flow } from "@qawolf/flows/cli";
 
-export default flow("Use runner expect", "Basic", async ({ test }) => {
-  await test("check value", async () => {
-    await expect("ready").toBeDefined();
+export default flow("Validate release payload", "Basic", async ({ inputs, test }) => {
+  await test("payload has expected shape", async () => {
+    expect(inputs).toMatchObject({
+      status: "ready",
+      generatedAt: expect.any(String),
+    });
   });
 });
 ```

--- a/qawolf/libraries/flows/api-reference/ios.mdx
+++ b/qawolf/libraries/flows/api-reference/ios.mdx
@@ -284,7 +284,9 @@ export default flow("Install profile", "iOS - iPhone 15 (iOS 26)", async () => {
 
 ## `expect`
 
-The exported `expect` value is a type-safe stub in package code and is replaced by the runner during execution.
+The exported `expect` is the assertion helper for iOS flows, backed by [`expect-webdriverio`](https://webdriver.io/docs/api/expect-webdriverio). All WebdriverIO matchers are available — including auto-retrying element matchers like `toBeDisplayed`, `toExist`, `toHaveText`, and `toHaveAttribute`. See the [expect-webdriverio matchers reference](https://webdriver.io/docs/api/expect-webdriverio) for the full list.
+
+Always import `expect` from `@qawolf/flows/ios` rather than from `expect-webdriverio` directly, so that QA Wolf's defaults (timeout, `toHaveScreenshot`) stay in effect.
 
 Example:
 
@@ -292,12 +294,16 @@ Example:
 import { expect, flow } from "@qawolf/flows/ios";
 
 export default flow(
-  "Use runner expect",
+  "Verify welcome screen",
   { target: "iOS - iPhone 15 (iOS 26)", launch: true },
   async ({ driver, test }) => {
-    await test("check driver", async () => {
-      await expect(driver).toBeDefined();
+    await test("welcome heading is visible", async () => {
+      const heading = driver.$("~welcome-heading");
+      await expect(heading).toBeDisplayed();
+      await expect(heading).toHaveText("Welcome");
     });
   },
 );
 ```
+
+For visual regression assertions with `expect(driver).toHaveScreenshot(...)`, see [Native mobile screenshots](/qawolf/visual-diffing-native-app).

--- a/qawolf/libraries/flows/api-reference/web.mdx
+++ b/qawolf/libraries/flows/api-reference/web.mdx
@@ -217,6 +217,31 @@ Electron launch-enabled flows receive the first Electron window as `page`.
 
 `testContextDependencies` is exported for runner and tooling integration. Flow authors should usually use the public callback parameters above instead of depending on the raw runner dependency list.
 
+## `expect`
+
+The exported `expect` is the assertion helper for web flows, backed by [Playwright's `expect`](https://playwright.dev/docs/test-assertions). All Playwright matchers are available — including auto-retrying locator matchers like `toBeVisible`, `toHaveText`, `toHaveURL`, and `toHaveScreenshot`. See [Playwright's locator assertions reference](https://playwright.dev/docs/api/class-locatorassertions) for the full list.
+
+Always import `expect` from `@qawolf/flows/web` rather than from `@playwright/test` directly, so that QA Wolf's defaults (custom timeout, visual diffing) stay in effect.
+
+Example:
+
+```ts
+import { expect, flow } from "@qawolf/flows/web";
+
+export default flow(
+  "Verify homepage",
+  { target: "Web - Chrome", launch: true },
+  async ({ page, test }) => {
+    await test("hero heading is visible", async () => {
+      await page.goto("https://example.com");
+      await expect(page.getByRole("heading", { name: "Example Domain" })).toBeVisible();
+    });
+  },
+);
+```
+
+For visual regression assertions with `expect(page).toHaveScreenshot(...)`, see [Web & Mobile web screenshots](/qawolf/visual-diffing).
+
 ## Defaults
 
 - default `kind` is browser launch

--- a/qawolf/libraries/flows/troubleshooting.mdx
+++ b/qawolf/libraries/flows/troubleshooting.mdx
@@ -13,15 +13,6 @@ Check:
 - the runner is setting the target before flow code executes
 - tests and local tooling call `configureTarget(...)` explicitly
 
-## `expect` Throws A Stub Error
-
-Cause: The package code is running outside the runner-provided execution environment.
-
-Check:
-
-- the flow is running through the expected runtime
-- local tooling is not calling the type-safe stub directly
-
 ## Callback Is Missing `page` Or `driver`
 
 Cause: The flow uses the no-`launch` path, so launched runtime objects are not injected into the callback automatically.
@@ -33,7 +24,7 @@ Check:
 
 ## Runtime API Called Outside The Flow Callback
 
-Cause: `launch()`, `expect`, `device`, or `platform.target` was called at the module level, outside the flow callback.
+Cause: `launch()`, `device`, or `platform.target` was called at the module level, outside the flow callback.
 
 Check:
 


### PR DESCRIPTION
## Overview of Problem

Per [GEN-1903](https://linear.app/qawolf/issue/GEN-1903) — the `expect` references in the flows API docs still describe the pre-GEN-1885 "type-safe stub" world. After the GEN-1885/GEN-1884/GEN-1907 chain lands, `expect` is the real assertion library on every entry point, and the troubleshooting page contains a stub-error section that can no longer fire.

## Overview of Changes

Five edits across four files refresh the references to match the post-unification surface:

- `android.mdx` / `ios.mdx`: `expect` section now points at `expect-webdriverio` matchers and cross-links to the native screenshot guide for `toHaveScreenshot`.
- `cli.mdx`: `expect` section now points at the `expect` package (Jest matchers) with a more realistic `toMatchObject` example.
- `web.mdx`: new `expect` section pointing at Playwright's `expect` with auto-retrying locator matchers and a cross-link to the web screenshot guide.
- `troubleshooting.mdx`: deletes the `` `expect` Throws A Stub Error `` section (stub can no longer fire after GEN-1885); drops `expect` from the "Runtime API Called Outside The Flow Callback" cause list (`expect` is now safe at module level).

