### PR TITLE
[GEN-1942] Document iOS/Android launch capabilities and migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "docs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/qawolf/libraries/flows/api-reference/android.mdx
+++ b/qawolf/libraries/flows/api-reference/android.mdx
@@ -243,6 +243,85 @@ await launch({
   If `app` is present but does not resolve to a value, launch does not fall back to `RUN_INPUT_PATH`.
 </Note>
 
+### Advanced Appium capabilities
+
+The named launch options above cover the most common settings. For anything else, use the `capabilities` escape hatch: its entries are spread into the underlying [webdriver.io `remote`](https://webdriver.io/docs/api) capabilities and passed straight to the Android driver.
+
+`startAndroid` is a thin wrapper around webdriver.io's `remote`, so capabilities that QA Wolf does not set itself are forwarded as-is. See the Appium references for the full list of available keys:
+
+- [Appium core capabilities](https://appium.io/docs/en/2.11/guides/caps/)
+- [UiAutomator2 (Android) driver capabilities](https://github.com/appium/appium-uiautomator2-driver)
+
+```ts
+import { flow, launch } from "@qawolf/flows/android";
+
+export default flow(
+  "Launch with custom capabilities",
+  "Android - Pixel",
+  async () => {
+    const { driver } = await launch({
+      // Named options cover the common knobs:
+      autoGrantPermissions: true,
+      waitForIdleTimeout: 10,
+      // Anything else is passed through verbatim:
+      capabilities: {
+        "appium:disableWindowAnimation": true,
+        "appium:uiautomator2ServerLaunchTimeout": 60000,
+      },
+    });
+
+    await driver.pause(1000);
+  },
+);
+```
+
+<Note>
+  Named options take precedence over `capabilities` for the same key. In particular, `autoGrantPermissions` and `noReset` are always applied (using their defaults when omitted), so configure those through the named options rather than `capabilities`.
+</Note>
+
+### Migrating from `wdio.startAndroid`
+
+Older flows obtained a `wdio` handle from the test context and called `startAndroid` directly. With the flow API, pass the same configuration through the flow's `launch` options instead — map the settings that have a named option, and route the rest through `capabilities`. The `driver` you receive is the same webdriver.io `Browser` handle, so there is no separate "raw" driver to obtain.
+
+```ts
+// Before: raw wdio.startAndroid
+const driver = await wdio.startAndroid({
+  "appium:app": process.env.ANDROID_PATH,
+  "appium:appPackage": "com.example.android",
+  "appium:autoGrantPermissions": true,
+  "appium:disableWindowAnimation": true,
+  "appium:waitForIdleTimeout": 10,
+});
+```
+
+```ts
+// After: flow launch options
+import { flow } from "@qawolf/flows/android";
+
+export default flow(
+  "Open Android app",
+  {
+    target: "Android - Pixel",
+    launch: {
+      app: { env: "ANDROID_PATH" },
+      appPackage: "com.example.android",
+      autoGrantPermissions: true,
+      waitForIdleTimeout: 10,
+      capabilities: {
+        "appium:disableWindowAnimation": true,
+      },
+    },
+  },
+  async ({ driver }) => {
+    await driver.pause(1000);
+  },
+);
+```
+
+<Note>
+  `app: { env: "ANDROID_PATH" }` reads the path from the environment variable named `ANDROID_PATH`, replacing the raw `"appium:app": process.env.ANDROID_PATH` form.
+</Note>
+
 ## `device`
 
 `device` is a runtime proxy over the Android emulator API. Use it for device-level operations — such as setting location, simulating sensors, or managing device state — that sit outside app UI interactions. Use `driver` for interacting with the app itself.

--- a/qawolf/libraries/flows/api-reference/android.mdx
+++ b/qawolf/libraries/flows/api-reference/android.mdx
@@ -250,7 +250,7 @@ The named launch options above cover the most common settings. For anything else
 `startAndroid` is a thin wrapper around webdriver.io's `remote`, so capabilities that QA Wolf does not set itself are forwarded as-is. See the Appium references for the full list of available keys:
 
 - [Appium core capabilities](https://appium.io/docs/en/2.11/guides/caps/)
-- [UiAutomator2 (Android) driver capabilities](https://github.com/appium/appium-uiautomator2-driver)
+- [UiAutomator2 (Android) driver capabilities](https://github.com/appium/appium-uiautomator2-driver/blob/v3.7.8/README.md#capabilities)
 
 ```ts
 import { flow, launch } from "@qawolf/flows/android";

--- a/qawolf/libraries/flows/api-reference/ios.mdx
+++ b/qawolf/libraries/flows/api-reference/ios.mdx
@@ -269,7 +269,7 @@ The named launch options above cover the most common settings. For anything else
 `startIos` is a thin wrapper around webdriver.io's `remote`, so capabilities that QA Wolf does not set itself are forwarded as-is. See the Appium references for the full list of available keys:
 
 - [Appium core capabilities](https://appium.io/docs/en/2.11/guides/caps/)
-- [XCUITest (iOS) driver capabilities](https://appium.github.io/appium-xcuitest-driver/latest/reference/capabilities/)
+- [XCUITest (iOS) driver capabilities](https://github.com/appium/appium-xcuitest-driver/blob/v8.3.1/docs/reference/capabilities.md)
 
 ```ts
 import { flow, launch } from "@qawolf/flows/ios";

--- a/qawolf/libraries/flows/api-reference/ios.mdx
+++ b/qawolf/libraries/flows/api-reference/ios.mdx
@@ -262,6 +262,88 @@ await launch({
   If `app` is present but does not resolve to a value, launch does not fall back to `RUN_INPUT_PATH`.
 </Note>
 
+### Advanced Appium capabilities
+
+The named launch options above cover the most common settings. For anything else, use the `capabilities` escape hatch: its entries are spread into the underlying [webdriver.io `remote`](https://webdriver.io/docs/api) capabilities and passed straight to the iOS driver.
+
+`startIos` is a thin wrapper around webdriver.io's `remote`, so capabilities that QA Wolf does not set itself are forwarded as-is. See the Appium references for the full list of available keys:
+
+- [Appium core capabilities](https://appium.io/docs/en/2.11/guides/caps/)
+- [XCUITest (iOS) driver capabilities](https://appium.github.io/appium-xcuitest-driver/latest/reference/capabilities/)
+
+```ts
+import { flow, launch } from "@qawolf/flows/ios";
+
+export default flow(
+  "Launch with custom capabilities",
+  "iOS - iPhone 15 (iOS 26)",
+  async () => {
+    const { driver } = await launch({
+      // Named options cover the common knobs:
+      respectSystemAlerts: true,
+      waitForIdleTimeout: 10,
+      // Anything else is passed through verbatim:
+      capabilities: {
+        "appium:resetOnSessionStartOnly": true,
+        "appium:settings[useFirstMatch]": "true",
+        "appium:waitForQuiescence": "false",
+      },
+    });
+
+    await driver.pause(1000);
+  },
+);
+```
+
+<Note>
+  Named options take precedence over `capabilities` for the same key. In particular, `noReset`, `respectSystemAlerts`, and `snapshotMaxDepth` are always applied (using their defaults when omitted), so configure those through the named options rather than `capabilities`.
+</Note>
+
+### Migrating from `wdio.startIos`
+
+Older flows obtained a `wdio` handle from the test context and called `startIos` directly. With the flow API, pass the same configuration through the flow's `launch` options instead — map the settings that have a named option, and route the rest through `capabilities`. The `driver` you receive is the same webdriver.io `Browser` handle, so there is no separate "raw" driver to obtain.
+
+```ts
+// Before: raw wdio.startIos
+const driver = await wdio.startIos({
+  "appium:app": process.env.IOS_PATH,
+  "appium:settings[respectSystemAlerts]": true,
+  "appium:resetOnSessionStartOnly": true,
+  "appium:settings[useFirstMatch]": "true",
+  "appium:waitForQuiescence": "false",
+  "appium:waitForIdleTimeout": 10,
+});
+```
+
+```ts
+// After: flow launch options
+import { flow } from "@qawolf/flows/ios";
+
+export default flow(
+  "Open iOS app",
+  {
+    target: "iOS - iPhone 15 (iOS 26)",
+    launch: {
+      app: { env: "IOS_PATH" },
+      respectSystemAlerts: true,
+      waitForIdleTimeout: 10,
+      capabilities: {
+        "appium:resetOnSessionStartOnly": true,
+        "appium:settings[useFirstMatch]": "true",
+        "appium:waitForQuiescence": "false",
+      },
+    },
+  },
+  async ({ driver }) => {
+    await driver.pause(1000);
+  },
+);
+```
+
+<Note>
+  `app: { env: "IOS_PATH" }` reads the path from the environment variable named `IOS_PATH`, replacing the raw `"appium:app": process.env.IOS_PATH` form.
+</Note>
+
 ## `device`
 
 `device` is a runtime proxy over the iOS simulator or device API. Use it for device-level operations — such as installing configuration profiles, simulating sensors, or managing device state — that sit outside app UI interactions. Use `driver` for interacting with the app itself.


### PR DESCRIPTION
## Overview

Documents how to pass advanced Appium capabilities to mobile flows and how to migrate older `wdio.startIos` / `wdio.startAndroid` calls to the flow `launch` API. Closes [GEN-1942](https://linear.app/qawolf/issue/GEN-1942).

Prompted by a POM migration question from Eric in Slack — the iOS/Android API reference covered the named launch options but didn't explain the `capabilities` escape hatch or the migration path off the raw `wdio` handle.

## Changes

Added two subsections to both `flows/api-reference/ios.mdx` and `android.mdx`:

- **Advanced Appium capabilities** — explains that `startIos`/`startAndroid` are thin wrappers around webdriver.io's `remote`, so any capability not covered by a named option can be passed through `capabilities` verbatim. Includes the Appium capability references (core, XCUITest, UiAutomator2) and a precedence note: named options — and the always-applied defaults (`noReset`, `respectSystemAlerts`, `snapshotMaxDepth` on iOS; `autoGrantPermissions`, `noReset` on Android) — win over `capabilities` for the same key.
- **Migrating from `wdio.startIos` / `wdio.startAndroid`** — before/after example mapping a raw `wdio` call to flow `launch` options, plus a note that `app: { env: "..." }` replaces the raw `"appium:app": process.env.X` form, and that the returned `driver` is the same webdriver.io `Browser` handle.

All option names, defaults, and precedence were validated against `packages/flows/src/{ios,android}/startOptions.ts`.
