### PR TITLE
docs(cli): correct CLI reference accuracy against shipped behavior

### DIFF
--- a/qawolf/libraries/cli/api-reference/commands.mdx
+++ b/qawolf/libraries/cli/api-reference/commands.mdx
@@ -137,7 +137,7 @@ Options:
 
 ## `doctor`
 
-Diagnoses problems running flows locally. Checks the CLI version, Node.js version, API key presence, QA Wolf API reachability, npm registry reachability, Playwright installation and browser availability for web flows, the Android SDK for Android flows, and scans flows for file-asset environment variable references (`TEAM_STORAGE_DIR`, `QAWOLF_*_DIR`, `RUN_*`).
+Diagnoses problems running flows locally. Checks your environment (CLI and Node.js versions, API key, connectivity) and the dependencies your flows need, such as Playwright browsers and the Android SDK.
 
 ```bash
 qawolf doctor
@@ -150,7 +150,7 @@ Options:
 
 ## `run`
 
-Triggers and manages QA Wolf runs on the platform. Unlike the local execution commands, `run` does not execute flows on your machine — it requires authentication and creates runs on the QA Wolf platform.
+Triggers and manages runs on the QA Wolf platform. Unlike the local execution commands, `run` does not execute flows on your machine and requires authentication.
 
 ### `run create`
 

--- a/qawolf/libraries/cli/api-reference/commands.mdx
+++ b/qawolf/libraries/cli/api-reference/commands.mdx
@@ -4,7 +4,7 @@ description: "Reference notes for every qawolf CLI command and flag."
 sidebarTitle: "Commands"
 ---
 
-The qawolf CLI exposes five top-level commands. Each section below documents the command's purpose, accepted arguments, and flags.
+The qawolf CLI exposes six top-level commands. Each section below documents the command's purpose, accepted arguments, and flags.
 
 ## `auth`
 
@@ -124,7 +124,7 @@ qawolf install android "flows/mobile/**"
 
 ## `init`
 
-Scaffolds a QA Wolf project in the current directory. Creates `qawolf.config.ts`, an example flow at `src/flows/example.flow.ts`, and `.qawolf/.gitignore`. Adds the `@qawolf/flows` dependency and a `test:e2e` script to `package.json`.
+Scaffolds a QA Wolf project in the current directory. Creates `qawolf.config.ts`, an example flow at `src/flows/example.flow.ts`, and `.qawolf/.gitignore`. When no `package.json` exists, creates one with `"type": "module"`, the `@qawolf/flows` dependency, and a `test:e2e` script; when one already exists, only adds the `test:e2e` script (after a prompt).
 
 ```bash
 qawolf init
@@ -137,7 +137,7 @@ Options:
 
 ## `doctor`
 
-Diagnoses problems running flows locally. Checks the CLI version, Node.js version, Playwright installation, browser availability for web flows, and the Android SDK for Android flows.
+Diagnoses problems running flows locally. Checks the CLI version, Node.js version, API key presence, QA Wolf API reachability, npm registry reachability, Playwright installation and browser availability for web flows, the Android SDK for Android flows, and scans flows for file-asset environment variable references (`TEAM_STORAGE_DIR`, `QAWOLF_*_DIR`, `RUN_*`).
 
 ```bash
 qawolf doctor
@@ -147,3 +147,23 @@ qawolf doctor --all
 Options:
 
 - `--all` — run every platform check, including platforms the project does not use. Default: `false`.
+
+## `run`
+
+Triggers and manages QA Wolf runs on the platform. Unlike the local execution commands, `run` does not execute flows on your machine — it requires authentication and creates runs on the QA Wolf platform.
+
+### `run create`
+
+Creates a run on the QA Wolf platform.
+
+```bash
+qawolf run create --environment-id <id>
+qawolf run create --environment-id <id> --flow-ids <id>... --environment-variables KEY=VALUE
+```
+
+Options:
+
+- `--environment-id <value>` — the ID of the environment to run.
+- `--environment-variables <KEY=VALUE...>` — environment variables to set for the run.
+- `--flow-ids <values...>` — limit the run to specific flow IDs.
+- `--ignore-rules` — ignore the environment's run rules.

--- a/qawolf/libraries/cli/api-reference/configuration.mdx
+++ b/qawolf/libraries/cli/api-reference/configuration.mdx
@@ -4,7 +4,7 @@ description: "Reference notes for the qawolf.config.ts file."
 sidebarTitle: "Configuration"
 ---
 
-`qawolf init` generates a `qawolf.config.ts` file at the project root, shown below. The CLI does not currently read this file — its fields are reserved for a future release. Today, behavior is controlled entirely by command-line flags.
+`qawolf init` generates a `qawolf.config.ts` file at the project root, shown below. The CLI does not currently read this file. Behavior is controlled by command-line flags.
 
 ```typescript
 export default {
@@ -17,12 +17,12 @@ export default {
 
 ## Fields
 
-These fields are not yet consumed by the CLI. The effective defaults are the flag defaults — use the corresponding flag to change behavior:
+These fields are not yet read by the CLI. Use the corresponding flag instead:
 
-- `outputDir` — reserved. Use `--output-dir` for run artifacts such as videos, traces, and HAR files. Flag default: `qawolf-output`.
-- `timeout` — reserved. Use `--timeout` for the per-flow timeout in milliseconds. Flag default: `30000`.
-- `retries` — reserved. Use `--retries` for the number of retries for each failing flow. Flag default: `0`.
-- `video` — reserved. Use `--video` for the video capture mode (`on`, `off`, or `retain-on-failure`). Flag default: `off`.
+- `outputDir` — directory for run artifacts such as videos, traces, and HAR files. Use `--output-dir`; defaults to `qawolf-output`.
+- `timeout` — per-flow timeout in milliseconds. Use `--timeout`; defaults to `30000`.
+- `retries` — number of retries for each failing flow. Use `--retries`; defaults to `0`.
+- `video` — video capture mode (`on`, `off`, or `retain-on-failure`). Use `--video`; defaults to `off`.
 
 ## Generated Project Layout
 

--- a/qawolf/libraries/cli/api-reference/configuration.mdx
+++ b/qawolf/libraries/cli/api-reference/configuration.mdx
@@ -4,7 +4,7 @@ description: "Reference notes for the qawolf.config.ts file."
 sidebarTitle: "Configuration"
 ---
 
-The qawolf CLI reads a `qawolf.config.ts` file at the project root. `qawolf init` generates this file with the defaults shown below. Fields set on the command line override the config.
+`qawolf init` generates a `qawolf.config.ts` file at the project root, shown below. The CLI does not currently read this file — its fields are reserved for a future release. Today, behavior is controlled entirely by command-line flags.
 
 ```typescript
 export default {
@@ -17,10 +17,12 @@ export default {
 
 ## Fields
 
-- `outputDir` — directory for run artifacts such as videos, traces, and HAR files. Overridden by `--output-dir`.
-- `timeout` — per-flow timeout in milliseconds. Overridden by `--timeout`.
-- `retries` — number of retries for each failing flow. Overridden by `--retries`.
-- `video` — video capture mode. One of `"on"`, `"off"`, or `"retain-on-failure"`. Overridden by `--video`.
+These fields are not yet consumed by the CLI. The effective defaults are the flag defaults — use the corresponding flag to change behavior:
+
+- `outputDir` — reserved. Use `--output-dir` for run artifacts such as videos, traces, and HAR files. Flag default: `qawolf-output`.
+- `timeout` — reserved. Use `--timeout` for the per-flow timeout in milliseconds. Flag default: `30000`.
+- `retries` — reserved. Use `--retries` for the number of retries for each failing flow. Flag default: `0`.
+- `video` — reserved. Use `--video` for the video capture mode (`on`, `off`, or `retain-on-failure`). Flag default: `off`.
 
 ## Generated Project Layout
 
@@ -28,4 +30,4 @@ export default {
 
 - `src/flows/example.flow.ts` — a minimal web flow used as a starting point.
 - `.qawolf/.gitignore` — ignores the contents of `.qawolf/` except for the file itself.
-- `package.json` — created or updated to include `"type": "module"`, the `@qawolf/flows` dependency, and a `"test:e2e": "qawolf flows run"` script.
+- `package.json` — when missing, created with `"type": "module"`, the `@qawolf/flows` dependency, and a `"test:e2e": "qawolf flows run"` script. When one already exists, only the `test:e2e` script is added.

--- a/qawolf/libraries/cli/api-reference/environment-variables.mdx
+++ b/qawolf/libraries/cli/api-reference/environment-variables.mdx
@@ -14,10 +14,6 @@ API key for the QA Wolf platform. Used by `flows pull`, `flows list --remote`, a
 
 Base URL for the QA Wolf platform API. Defaults to `https://app.qawolf.com`. Trailing slashes are stripped.
 
-## `QAWOLF_LOG_LEVEL`
-
-Controls mirroring of structured logs to stderr. One of `error`, `warn`, `info`, `debug`, `trace`, or `silent`. Defaults to `silent`. The `--verbose` flag forces `debug`. Logs are always written to the log file regardless of this setting.
-
 ## `ANDROID_HOME`
 
 Path to the Android SDK root. Required by `qawolf install android` and by Android flow execution. `ANDROID_SDK_ROOT` is accepted as a fallback.

--- a/qawolf/libraries/cli/api-reference/environment-variables.mdx
+++ b/qawolf/libraries/cli/api-reference/environment-variables.mdx
@@ -14,6 +14,10 @@ API key for the QA Wolf platform. Used by `flows pull`, `flows list --remote`, a
 
 Base URL for the QA Wolf platform API. Defaults to `https://app.qawolf.com`. Trailing slashes are stripped.
 
+## `QAWOLF_LOG_LEVEL`
+
+Controls mirroring of structured logs to stderr. One of `error`, `warn`, `info`, `debug`, `trace`, or `silent`. Defaults to `silent`. The `--verbose` flag forces `debug`. Logs are always written to the log file regardless of this setting.
+
 ## `ANDROID_HOME`
 
 Path to the Android SDK root. Required by `qawolf install android` and by Android flow execution. `ANDROID_SDK_ROOT` is accepted as a fallback.

--- a/qawolf/libraries/cli/api-reference/index.mdx
+++ b/qawolf/libraries/cli/api-reference/index.mdx
@@ -34,9 +34,7 @@ The following flags apply to every command:
 
 When a recognized CI environment is detected (`CI`, `GITHUB_ACTIONS`, `GITLAB_CI`, `CIRCLECI`, `JENKINS_URL`, `BUILDKITE`), output defaults to JSON. When a recognized agent environment is detected (`CLAUDE_CODE`, `CURSOR_SESSION_ID`), output defaults to agent mode.
 
-### Scripting output
-
-With `--json` or `--agent`, a command's structured result is emitted as a single JSON line on stdout, while progress and diagnostic text goes to stderr. Pipe stdout to parse results in scripts.
+With `--json` or `--agent`, the structured result is written to stdout and diagnostic text to stderr, so scripts can parse stdout directly.
 
 ## Exit Codes
 

--- a/qawolf/libraries/cli/api-reference/index.mdx
+++ b/qawolf/libraries/cli/api-reference/index.mdx
@@ -13,6 +13,7 @@ Use this section for stable command descriptions, flags, configuration, environm
 - [`qawolf install`](/qawolf/libraries/cli/api-reference/commands#install) — install runtime dependencies for the project.
 - [`qawolf init`](/qawolf/libraries/cli/api-reference/commands#init) — scaffold a project in the current directory.
 - [`qawolf doctor`](/qawolf/libraries/cli/api-reference/commands#doctor) — diagnose problems running flows locally.
+- [`qawolf run`](/qawolf/libraries/cli/api-reference/commands#run) — trigger and manage QA Wolf runs on the platform.
 
 Example invocation:
 
@@ -29,8 +30,13 @@ The following flags apply to every command:
 - `--verbose` — emits debug logs to stderr.
 - `--json` — formats output as JSON.
 - `--agent` — formats output for agent consumption.
+- `-V, --version` — prints the CLI version.
 
 When a recognized CI environment is detected (`CI`, `GITHUB_ACTIONS`, `GITLAB_CI`, `CIRCLECI`, `JENKINS_URL`, `BUILDKITE`), output defaults to JSON. When a recognized agent environment is detected (`CLAUDE_CODE`, `CURSOR_SESSION_ID`), output defaults to agent mode.
+
+### Scripting output
+
+With `--json` or `--agent`, a command's structured result is emitted as a single JSON line on stdout, while progress and diagnostic text goes to stderr. Pipe stdout to parse results in scripts.
 
 ## Exit Codes
 

--- a/qawolf/local-execution/authenticate.mdx
+++ b/qawolf/local-execution/authenticate.mdx
@@ -14,7 +14,7 @@ The CLI ships in two forms: an npm package and a precompiled standalone binary.
 ### Install with npm
 
 <Check>
-  Node.js 24 or later is required.
+  Node.js 22.12 or later is required.
 </Check>
 
 ```bash
@@ -23,7 +23,7 @@ npm install -g @qawolf/cli
 
 ### Install a precompiled binary
 
-Download the binary for your platform from [GitHub Releases](https://github.com/qawolf/cli/releases). Builds are published for Linux x64, macOS (Apple Silicon and Intel), and Windows x64. The binary has no Node.js runtime dependency. Extract the archive, then move the binary into a directory on your `PATH`.
+Download the binary for your platform from [GitHub Releases](https://github.com/qawolf/cli/releases). Builds are published for Linux (x64 and arm64), macOS (Apple Silicon and Intel), and Windows x64. The binary has no Node.js runtime dependency. Extract the archive, then move the binary into a directory on your `PATH`.
 
 ### Verify
 

--- a/qawolf/local-execution/diagnose-problems.mdx
+++ b/qawolf/local-execution/diagnose-problems.mdx
@@ -21,9 +21,13 @@ When a flow run fails for reasons that aren't in the flow itself — a missing b
 
     - the CLI version
     - the Node.js version against the required minimum
+    - whether an API key is configured
+    - whether the QA Wolf API is reachable
+    - whether the npm registry is reachable
     - the Playwright installation, if any flow targets a browser
     - browser availability for each target the project uses
     - the Android SDK, if any flow targets Android
+    - flows that reference file-asset environment variables (`TEAM_STORAGE_DIR`, `QAWOLF_*_DIR`, `RUN_*`)
   </Step>
   <Step>
     Read the output. Each check reports a pass, a warning, or a failure, with a remediation hint when it fails.
@@ -42,10 +46,10 @@ This is useful when copying the project to a new machine and you want a single c
 
 ## Read the log file
 
-The CLI writes structured logs to the platform's user cache directory:
+The CLI writes structured logs to the platform's log directory:
 
-- macOS: `~/Library/Caches/qawolf/qawolf.log`
-- Linux: `$XDG_CACHE_HOME/qawolf/qawolf.log` or `~/.cache/qawolf/qawolf.log`
+- macOS: `~/Library/Logs/qawolf/cli.log`
+- Linux: `$XDG_STATE_HOME/qawolf/cli.log` or `~/.local/state/qawolf/cli.log`
 
 Run with `--verbose` to mirror debug logs to stderr in real time:
 

--- a/qawolf/local-execution/diagnose-problems.mdx
+++ b/qawolf/local-execution/diagnose-problems.mdx
@@ -21,13 +21,11 @@ When a flow run fails for reasons that aren't in the flow itself — a missing b
 
     - the CLI version
     - the Node.js version against the required minimum
-    - whether an API key is configured
-    - whether the QA Wolf API is reachable
-    - whether the npm registry is reachable
+    - your API key and connectivity to QA Wolf and the npm registry
     - the Playwright installation, if any flow targets a browser
     - browser availability for each target the project uses
     - the Android SDK, if any flow targets Android
-    - flows that reference file-asset environment variables (`TEAM_STORAGE_DIR`, `QAWOLF_*_DIR`, `RUN_*`)
+    - flow references to file assets that may not be available locally
   </Step>
   <Step>
     Read the output. Each check reports a pass, a warning, or a failure, with a remediation hint when it fails.

--- a/qawolf/local-execution/install-dependencies.mdx
+++ b/qawolf/local-execution/install-dependencies.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Install dependencies"
 icon: "download"
 ---
 
-[`qawolf flows run --env <env>`](/qawolf/local-execution/run-flows-locally) installs runtime dependencies automatically before its first run, so most users never invoke `qawolf install` directly. Reach for it when you want to install ahead of time — for example, to warm a CI cache between the checkout step and the run step — or when you're running flows from a [local-only project](/qawolf/local-execution/set-up-a-project).
+[`qawolf flows run --env <env>`](/qawolf/local-execution/run-flows-locally) installs npm dependencies and Playwright browsers automatically before its first run, so web-only users rarely invoke `qawolf install` directly. Android dependencies — system images, AVDs, and the Appium uiautomator2 driver — are not installed during a run: run `qawolf install android` (or `qawolf install`) explicitly before running Android flows. Also reach for `qawolf install` when you want to install ahead of time — for example, to warm a CI cache between the checkout step and the run step — or when you're running flows from a [local-only project](/qawolf/local-execution/set-up-a-project).
 
 ## Install everything the project needs
 
@@ -55,4 +55,4 @@ The command installs the Appium uiautomator2 driver, downloads the Android syste
 
 ## iOS support
 
-iOS flows are not yet executable by the CLI. `qawolf install` skips them and prints a clear error if you select an iOS-only pattern. iOS support requires macOS with Xcode when it ships.
+iOS flows are not yet executable by the CLI. `qawolf install` skips them with a warning ("iOS targets are not supported in v0.1.") rather than erroring. iOS support requires macOS with Xcode when it ships.

--- a/qawolf/local-execution/install-dependencies.mdx
+++ b/qawolf/local-execution/install-dependencies.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Install dependencies"
 icon: "download"
 ---
 
-[`qawolf flows run --env <env>`](/qawolf/local-execution/run-flows-locally) installs npm dependencies and Playwright browsers automatically before its first run, so web-only users rarely invoke `qawolf install` directly. Android dependencies — system images, AVDs, and the Appium uiautomator2 driver — are not installed during a run: run `qawolf install android` (or `qawolf install`) explicitly before running Android flows. Also reach for `qawolf install` when you want to install ahead of time — for example, to warm a CI cache between the checkout step and the run step — or when you're running flows from a [local-only project](/qawolf/local-execution/set-up-a-project).
+[`qawolf flows run --env <env>`](/qawolf/local-execution/run-flows-locally) installs npm dependencies and Playwright browsers automatically before its first run, so web-only users rarely invoke `qawolf install` directly. Android dependencies are not installed during a run; run `qawolf install android` before running Android flows. Also reach for `qawolf install` to install ahead of time (for example, to warm a CI cache between the checkout step and the run step) or when running flows from a [local-only project](/qawolf/local-execution/set-up-a-project).
 
 ## Install everything the project needs
 
@@ -55,4 +55,4 @@ The command installs the Appium uiautomator2 driver, downloads the Android syste
 
 ## iOS support
 
-iOS flows are not yet executable by the CLI. `qawolf install` skips them with a warning ("iOS targets are not supported in v0.1.") rather than erroring. iOS support requires macOS with Xcode when it ships.
+iOS flows are not yet executable by the CLI. `qawolf install` skips them with a warning. iOS support requires macOS with Xcode when it ships.

--- a/qawolf/local-execution/pull-flows.mdx
+++ b/qawolf/local-execution/pull-flows.mdx
@@ -45,7 +45,8 @@ Inside `.qawolf/<env>/`, the CLI stores:
 
 - the flow source files
 - a manifest tracking what was pulled and when
-- a `.env` file with the environment's variables, loaded automatically by `qawolf flows run`
+- an `assets/` directory with the file assets from QA Wolf team storage
+- a `.env` file with the environment's variables, loaded automatically by `qawolf flows run`; it also sets `TEAM_STORAGE_DIR` to the `assets/` directory so flow references to team storage resolve locally
 
 ## Refresh a pulled environment
 
@@ -66,4 +67,4 @@ qawolf flows list "checkout/**" --remote
 
 ## What's not pulled
 
-File assets stored in QA Wolf cloud storage are not pulled. Web flows that read paths from `QAWOLF_*_DIR` environment variables cannot run locally until the assets are available on the machine. Mobile flows reference the APK or IPA build through an environment variable — make sure that path is set before running.
+Mobile app binaries are not downloaded. Mobile flows reference the APK or IPA build through a `RUN_*` environment variable — make sure that path points to a build available on the machine before running.

--- a/qawolf/local-execution/pull-flows.mdx
+++ b/qawolf/local-execution/pull-flows.mdx
@@ -45,8 +45,8 @@ Inside `.qawolf/<env>/`, the CLI stores:
 
 - the flow source files
 - a manifest tracking what was pulled and when
-- an `assets/` directory with the file assets from QA Wolf team storage
-- a `.env` file with the environment's variables, loaded automatically by `qawolf flows run`; it also sets `TEAM_STORAGE_DIR` to the `assets/` directory so flow references to team storage resolve locally
+- an `assets/` directory with the environment's file assets from team storage, wired up so flows resolve them locally
+- a `.env` file with the environment's variables, loaded automatically by `qawolf flows run`
 
 ## Refresh a pulled environment
 
@@ -67,4 +67,4 @@ qawolf flows list "checkout/**" --remote
 
 ## What's not pulled
 
-Mobile app binaries are not downloaded. Mobile flows reference the APK or IPA build through a `RUN_*` environment variable — make sure that path points to a build available on the machine before running.
+Mobile app binaries are not downloaded. Mobile flows reference the APK or IPA build through an environment variable, so make sure that path points to a build available on the machine before running. Flows that read paths from runner-only `QAWOLF_*_DIR` environment variables also cannot resolve those paths locally; `qawolf doctor` flags both cases.

--- a/qawolf/local-execution/run-flows-locally.mdx
+++ b/qawolf/local-execution/run-flows-locally.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Run flows locally"
 icon: "play"
 ---
 
-`qawolf flows run --env <env>` is the recommended path. It runs your team's flows from the local `.qawolf/<env>/` cache, pulling them first only if they are not already cached locally, then installs the npm dependencies and Playwright browsers they need and runs them. Android flows require installing the Android tooling first with `qawolf install android` — see [Install dependencies](/qawolf/local-execution/install-dependencies).
+`qawolf flows run --env <env>` is the recommended path. It runs your team's flows from the local `.qawolf/<env>/` cache, pulling them first only if they are not already cached locally, then installs the npm dependencies and Playwright browsers they need and runs them. Android flows require installing the Android tooling first with `qawolf install android`. See [Install dependencies](/qawolf/local-execution/install-dependencies).
 
 <Check>
   Authenticate the CLI first. See [Authenticate the QA Wolf CLI](/qawolf/local-execution/authenticate).
@@ -28,7 +28,7 @@ icon: "play"
 
     1. checks the local `.qawolf/staging/` cache, and pulls the environment's flows only if they are not already cached
     2. loads the environment's `.env` file
-    3. installs the npm dependencies and Playwright browsers the flows need — Android system images and AVDs are not installed automatically; run `qawolf install android` first
+    3. installs the npm dependencies and Playwright browsers the flows need
     4. runs every flow
 
     To refresh the local cache against the platform, run `qawolf flows pull --env staging`. See [Pull your team's flows](/qawolf/local-execution/pull-flows).
@@ -129,6 +129,6 @@ The CLI discovers flows matching `**/*.flow.{ts,js}` in the current directory an
 ## Current limitations
 
 - Android flows must run with `--workers 1`. Parallel execution is supported for web flows only.
-- iOS flows are not executed. When iOS flows are selected for a run, the CLI skips them with a warning rather than erroring.
+- iOS flows are not executed. The CLI skips them with a warning.
 - Flows that target the legacy `"Basic"` platform pull successfully but cannot be executed by the CLI.
-- Dynamic-target flows — flows where `target` is a computed value rather than a string literal — are skipped because the CLI cannot determine the platform ahead of time.
+- Flows where `target` is a computed value rather than a string literal are skipped because the CLI cannot determine the platform ahead of time.

--- a/qawolf/local-execution/run-flows-locally.mdx
+++ b/qawolf/local-execution/run-flows-locally.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Run flows locally"
 icon: "play"
 ---
 
-`qawolf flows run --env <env>` is the recommended path. It runs your team's flows from the local `.qawolf/<env>/` cache, pulling them first only if they are not already cached locally, then installs the runtime dependencies they need (Playwright browsers, Android system images and AVDs) and runs them.
+`qawolf flows run --env <env>` is the recommended path. It runs your team's flows from the local `.qawolf/<env>/` cache, pulling them first only if they are not already cached locally, then installs the npm dependencies and Playwright browsers they need and runs them. Android flows require installing the Android tooling first with `qawolf install android` — see [Install dependencies](/qawolf/local-execution/install-dependencies).
 
 <Check>
   Authenticate the CLI first. See [Authenticate the QA Wolf CLI](/qawolf/local-execution/authenticate).
@@ -28,7 +28,7 @@ icon: "play"
 
     1. checks the local `.qawolf/staging/` cache, and pulls the environment's flows only if they are not already cached
     2. loads the environment's `.env` file
-    3. installs the Playwright browsers and Android dependencies the flows need
+    3. installs the npm dependencies and Playwright browsers the flows need — Android system images and AVDs are not installed automatically; run `qawolf install android` first
     4. runs every flow
 
     To refresh the local cache against the platform, run `qawolf flows pull --env staging`. See [Pull your team's flows](/qawolf/local-execution/pull-flows).
@@ -44,7 +44,7 @@ qawolf flows run --env staging "checkout/**"
 qawolf flows run --env staging "src/flows/login.flow.ts"
 ```
 
-Patterns are matched against absolute paths in the current directory and against the pulled cache under `.qawolf/<env>/`.
+With `--env`, patterns are matched against the pulled cache under `.qawolf/<env>/`. Without `--env`, patterns are matched against both the current directory and the pulled cache.
 
 ## Watch the browser
 
@@ -129,6 +129,6 @@ The CLI discovers flows matching `**/*.flow.{ts,js}` in the current directory an
 ## Current limitations
 
 - Android flows must run with `--workers 1`. Parallel execution is supported for web flows only.
-- iOS flows are not executed. The CLI prints a clear error if an iOS flow is selected for a run.
+- iOS flows are not executed. When iOS flows are selected for a run, the CLI skips them with a warning rather than erroring.
 - Flows that target the legacy `"Basic"` platform pull successfully but cannot be executed by the CLI.
-- Dynamic-target flows — flows where `target` is a computed value rather than a string literal — are included in every run because the CLI cannot determine the platform ahead of time.
+- Dynamic-target flows — flows where `target` is a computed value rather than a string literal — are skipped because the CLI cannot determine the platform ahead of time.

--- a/qawolf/local-execution/set-up-a-project.mdx
+++ b/qawolf/local-execution/set-up-a-project.mdx
@@ -32,9 +32,9 @@ The command creates the following files:
 
 - `qawolf.config.ts` — the project configuration. See the [Configuration reference](/qawolf/libraries/cli/api-reference/configuration) for the full list of fields.
 - `src/flows/example.flow.ts` — a minimal web flow you can edit or delete.
-- `.qawolf/.gitignore` — ignores everything inside `.qawolf/`, such as flows pulled from the platform. Run artifacts land in `qawolf-output/` by default, which this file does not cover.
+- `.qawolf/.gitignore` — ignores the contents of `.qawolf/`, such as flows pulled from the platform. Run artifacts in `qawolf-output/` are not covered.
 
-If your directory has no `package.json`, the CLI creates one with `"type": "module"`, the `@qawolf/flows` dependency, and a `test:e2e` script that runs `qawolf flows run`. If a `package.json` already exists, the CLI only adds the `test:e2e` script (after a prompt) — it does not change your dependencies or module type.
+If your directory has no `package.json`, the CLI creates one with `"type": "module"`, the `@qawolf/flows` dependency, and a `test:e2e` script that runs `qawolf flows run`. If a `package.json` already exists, the CLI only adds the `test:e2e` script.
 
 ## Write a flow
 

--- a/qawolf/local-execution/set-up-a-project.mdx
+++ b/qawolf/local-execution/set-up-a-project.mdx
@@ -32,9 +32,9 @@ The command creates the following files:
 
 - `qawolf.config.ts` — the project configuration. See the [Configuration reference](/qawolf/libraries/cli/api-reference/configuration) for the full list of fields.
 - `src/flows/example.flow.ts` — a minimal web flow you can edit or delete.
-- `.qawolf/.gitignore` — ignores artifacts produced by `qawolf flows run` and flows pulled from the platform.
+- `.qawolf/.gitignore` — ignores everything inside `.qawolf/`, such as flows pulled from the platform. Run artifacts land in `qawolf-output/` by default, which this file does not cover.
 
-If your directory has no `package.json`, the CLI creates one. Otherwise, it adds the `@qawolf/flows` dependency and a `test:e2e` script that runs `qawolf flows run`.
+If your directory has no `package.json`, the CLI creates one with `"type": "module"`, the `@qawolf/flows` dependency, and a `test:e2e` script that runs `qawolf flows run`. If a `package.json` already exists, the CLI only adds the `test:e2e` script (after a prompt) — it does not change your dependencies or module type.
 
 ## Write a flow
 


### PR DESCRIPTION
## Summary

Accuracy pass over the new CLI docs on `local-execution-cli` (#140), verifying behavioral claims against the shipped CLI (qawolf/cli @ 3618e07). Kept at user-level detail — internals stay in the source.

- **Setup & install** — corrected the Node requirement (22.12+, not 24) and binary platform list; clarified what auto-installs during runs (npm deps + Playwright browsers; Android tooling needs `qawolf install android`); fixed what `init` does when `package.json` already exists.
- **Running & pulling flows** — dynamic-target and iOS flows are skipped with a warning, not errors; with `--env`, patterns expand only against the env cache dir; `flows pull` does sync team-storage file assets — the remaining caveats are mobile app binaries and runner-only directories.
- **Diagnostics** — corrected the log file path per platform and summarized what `doctor` checks.
- **API reference** — documented the missing `run` command and `-V, --version`; reframed `qawolf.config.ts` as written by `init` but not currently read by the CLI, so effective defaults are the flag defaults.

## Test Plan

- [x] Every claim verified against qawolf/cli main @ 3618e07 (source + `--help` output)
- [x] `npx mintlify broken-links` passes