### PR TITLE
docs(mobile): add iOS allowlisted & private devices

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -96,6 +96,28 @@
             ]
           },
           {
+            "group": "Mobile",
+            "icon": "smartphone",
+            "pages": [
+              {
+                "group": "Android",
+                "icon": "bot",
+                "pages": [
+                  "qawolf/mobile/android-devices"
+                ]
+              },
+              {
+                "group": "iOS",
+                "icon": "apple",
+                "pages": [
+                  "qawolf/mobile/ios-devices",
+                  "qawolf/mobile/ios-allowlisted-devices",
+                  "qawolf/mobile/ios-private-devices"
+                ]
+              }
+            ]
+          },
+          {
             "group": "Setup",
             "icon": "sliders-horizontal",
             "pages": [

--- a/qawolf/libraries/flows/api-reference/index.mdx
+++ b/qawolf/libraries/flows/api-reference/index.mdx
@@ -85,10 +85,4 @@ type Target =
   | "Latest iOS (iPhone)";
 ```
 
-<Note>
-  Allowlisted targets are used for the features that don't work after resigning such as universal links via associated domains.
-  
-  Private targets are used for advanced cases where the targets have to be allocated for a single team such as MDM testing.
-
-  Contact your QA Wolf representative to enable these targets.
-</Note>
+See [Allowlisted devices](/qawolf/mobile/ios-allowlisted-devices) and [Private devices](/qawolf/mobile/ios-private-devices) for when to use these targets and how to set them up.

--- a/qawolf/mobile/android-devices.mdx
+++ b/qawolf/mobile/android-devices.mdx
@@ -1,0 +1,25 @@
+---
+title: "Android devices"
+description: "QA Wolf runs your Android tests on ephemeral emulators that start from a clean state for every run."
+sidebarTitle: "Android"
+---
+
+QA Wolf runs your Android tests on ephemeral emulators. A fresh emulator is provisioned for each run and discarded when the run finishes, so every run starts from a clean, predictable state with no data or configuration carried over from a previous run.
+
+Because emulators are created on demand, you do not reserve or configure devices yourself. Choose an Android target in your flow and QA Wolf allocates an emulator for it.
+
+```typescript
+import { flow } from "@qawolf/flows/android";
+
+export default flow(
+  "Open Android app",
+  { target: "Android - Pixel 9 (Android 16)", launch: true },
+  async ({ driver, test }) => {
+    await test("app launches", async () => {
+      await driver.pause(1000);
+    });
+  },
+);
+```
+
+See the [Android Reference](/qawolf/libraries/flows/api-reference/android) for the full list of targets and device controls.

--- a/qawolf/mobile/ios-allowlisted-devices.mdx
+++ b/qawolf/mobile/ios-allowlisted-devices.mdx
@@ -63,7 +63,7 @@ import { flow } from "@qawolf/flows/ios";
 export default flow(
   "Test push notifications",
   {
-    target: "iOS - iPhone 15 (iOS 26)",
+    target: "iOS - iPhone 15 (iOS 26) (allowlisted)",
     launch: {
       app: { env: "IPA_BUILD_LOCATION" },
       capabilities: {

--- a/qawolf/mobile/ios-allowlisted-devices.mdx
+++ b/qawolf/mobile/ios-allowlisted-devices.mdx
@@ -1,0 +1,80 @@
+---
+title: "Allowlisted devices (iOS)"
+description: "Test features that don't work on a resigned app — like push notifications and universal links — by signing your app for QA Wolf's devices."
+sidebarTitle: "Allowlisted devices"
+---
+
+QA Wolf installs unreleased iOS builds by resigning your app, which works for most tests. A few features cannot be tested on a resigned app, including:
+
+- Push notifications
+- Universal links (associated domains)
+
+These features depend on capabilities that require a provisioning profile tied to your app's bundle ID. Because you own the bundle ID, only you can produce that profile — so for these tests you sign the app for QA Wolf's devices instead of letting QA Wolf resign it. Devices set up this way are called allowlisted devices.
+
+<Note>
+  Contact your QA Wolf representative to enable allowlisted devices for your team.
+</Note>
+
+## Sign the app for QA Wolf's devices
+
+<Steps>
+  <Step>
+    QA Wolf shares a set of device UDIDs with you. Add these devices to the provisioning profile for your app's bundle ID.
+  </Step>
+  <Step>
+    Build and sign the app for those devices using that profile.
+  </Step>
+</Steps>
+
+## Include QA Wolf instrumentation
+
+When QA Wolf resigns an app, it injects an instrumentation library that lets your tests mock system behavior. When you sign the app yourself, include this library so mocking still works.
+
+- **Fastlane users** — use the `inject_qawolf_instrumentation` action from the [QA Wolf Fastlane plugin](https://github.com/qawolf/fastlane-plugin-qawolf).
+- **Non-Fastlane users** — use the injection [script in the plugin repository](https://github.com/qawolf/fastlane-plugin-qawolf/tree/main/scripts).
+
+<Warning>
+  After injecting the instrumentation library, resign the IPA. Fastlane users can use the [Fastlane resign action](https://docs.fastlane.tools/actions/resign/); otherwise resign the IPA with whatever your pipeline already uses.
+</Warning>
+
+## Target allowlisted devices
+
+Set `targetDevices` to `Allowlisted Device` in your workflow's target configuration so the run is scheduled on the devices you signed the app for. `deviceModel` and `iosVersion` depend on the devices QA Wolf allocated for your team.
+
+```typescript
+{
+  platform: "ios",
+  schemaVersion: 1,
+  meta: {
+    deviceModel: "iPhone 15",
+    iosVersion: "26",
+    targetDevices: "Allowlisted Device",
+  },
+}
+```
+
+## Disable resigning
+
+Because you signed the app yourself, disable QA Wolf's resigning when the app launches by setting the `qawolf:disableResigning` capability:
+
+```typescript
+import { flow } from "@qawolf/flows/ios";
+
+export default flow(
+  "Test push notifications",
+  {
+    target: "iOS - iPhone 15 (iOS 26)",
+    launch: {
+      app: { env: "IPA_BUILD_LOCATION" },
+      capabilities: {
+        "qawolf:disableResigning": true,
+      },
+    },
+  },
+  async ({ driver, test }) => {
+    await test("notification is received", async () => {
+      // your test steps
+    });
+  },
+);
+```

--- a/qawolf/mobile/ios-allowlisted-devices.mdx
+++ b/qawolf/mobile/ios-allowlisted-devices.mdx
@@ -63,7 +63,15 @@ import { flow } from "@qawolf/flows/ios";
 export default flow(
   "Test push notifications",
   {
-    target: "iOS - iPhone 15 (iOS 26) (allowlisted)",
+    target: {
+      platform: "ios",
+      schemaVersion: 1,
+      meta: {
+        deviceModel: "iPhone 15",
+        iosVersion: "26",
+        targetDevices: "Allowlisted Device",
+      },
+    },
     launch: {
       app: { env: "IPA_BUILD_LOCATION" },
       capabilities: {

--- a/qawolf/mobile/ios-devices.mdx
+++ b/qawolf/mobile/ios-devices.mdx
@@ -6,6 +6,22 @@ sidebarTitle: "iOS"
 
 QA Wolf runs your iOS tests on real, physical devices. By default these devices are shared across customers, and QA Wolf cleans up data and configuration between runs so each run starts from a known state.
 
+Choose an iOS target in your flow and QA Wolf allocates a device for it.
+
+```typescript
+import { flow } from "@qawolf/flows/ios";
+
+export default flow(
+  "Open iOS app",
+  { target: "Latest iOS (iPhone)", launch: true },
+  async ({ driver, test }) => {
+    await test("app launches", async () => {
+      await driver.pause(1000);
+    });
+  },
+);
+```
+
 To install unreleased builds on shared devices without a per-app provisioning profile, QA Wolf resigns your app during installation. Resigning covers most test cases, but two situations need a different setup:
 
 - Some features cannot be tested on a resigned app — see [Allowlisted devices](/qawolf/mobile/ios-allowlisted-devices).

--- a/qawolf/mobile/ios-devices.mdx
+++ b/qawolf/mobile/ios-devices.mdx
@@ -1,0 +1,14 @@
+---
+title: "iOS devices"
+description: "QA Wolf runs your iOS tests on real devices, with allowlisted and private device options for cases the shared pool can't cover."
+sidebarTitle: "iOS"
+---
+
+QA Wolf runs your iOS tests on real, physical devices. By default these devices are shared across customers, and QA Wolf cleans up data and configuration between runs so each run starts from a known state.
+
+To install unreleased builds on shared devices without a per-app provisioning profile, QA Wolf resigns your app during installation. Resigning covers most test cases, but two situations need a different setup:
+
+- Some features cannot be tested on a resigned app — see [Allowlisted devices](/qawolf/mobile/ios-allowlisted-devices).
+- Some tests need devices that are not shared with other customers — see [Private devices](/qawolf/mobile/ios-private-devices).
+
+See the [iOS Reference](/qawolf/libraries/flows/api-reference/ios) for the full list of targets and device controls.

--- a/qawolf/mobile/ios-private-devices.mdx
+++ b/qawolf/mobile/ios-private-devices.mdx
@@ -40,3 +40,17 @@ Set `targetDevices` to `Team Dedicated Device` in your workflow's target configu
   },
 }
 ```
+
+```typescript
+import { flow } from "@qawolf/flows/ios";
+
+export default flow(
+  "Test on a dedicated device",
+  { target: "iOS - iPhone 15 (iOS 26) (private)", launch: true },
+  async ({ driver, test }) => {
+    await test("app launches", async () => {
+      // your test steps
+    });
+  },
+);
+```

--- a/qawolf/mobile/ios-private-devices.mdx
+++ b/qawolf/mobile/ios-private-devices.mdx
@@ -40,17 +40,3 @@ Set `targetDevices` to `Team Dedicated Device` in your workflow's target configu
   },
 }
 ```
-
-```typescript
-import { flow } from "@qawolf/flows/ios";
-
-export default flow(
-  "Test on a dedicated device",
-  { target: "iOS - iPhone 15 (iOS 26) (private)", launch: true },
-  async ({ driver, test }) => {
-    await test("app launches", async () => {
-      // your test steps
-    });
-  },
-);
-```

--- a/qawolf/mobile/ios-private-devices.mdx
+++ b/qawolf/mobile/ios-private-devices.mdx
@@ -1,0 +1,42 @@
+---
+title: "Private devices (iOS)"
+description: "Run iOS tests on devices dedicated to your team for cases that need full device control or persistence across runs."
+sidebarTitle: "Private devices"
+---
+
+By default, QA Wolf shares iOS devices across customers and cleans up data and configuration between runs. Some tests need full control over a device, or need data and configuration to persist between runs. For these cases, QA Wolf can dedicate devices to a single team. These are called private devices.
+
+Example cases:
+
+- MDM (Mobile Device Management) testing
+- Tests that need data or configuration to persist across runs
+
+<Note>
+  Contact your QA Wolf representative to enable private devices for your team.
+</Note>
+
+## Allowlisted vs private devices
+
+| | Allowlisted devices | Private devices |
+| --- | --- | --- |
+| Device pool | Part of the shared device pool | Dedicated to your team |
+| Use case | Features that don't work on a resigned app | Tests where a device can't be shared |
+| State between runs | Cleaned up between every run | Can persist data and configuration |
+
+Private devices can do anything [allowlisted devices](/qawolf/mobile/ios-allowlisted-devices) can. You can share the UDIDs of private devices and skip resigning when that is needed for your tests.
+
+## Target private devices
+
+Set `targetDevices` to `Team Dedicated Device` in your workflow's target configuration so the run is scheduled on your team's devices. `deviceModel` and `iosVersion` depend on the devices QA Wolf allocated for your team.
+
+```typescript
+{
+  platform: "ios",
+  schemaVersion: 1,
+  meta: {
+    deviceModel: "iPhone 15",
+    iosVersion: "26",
+    targetDevices: "Team Dedicated Device",
+  },
+}
+```


### PR DESCRIPTION
## What

Adds a new **Mobile** group under the **Features** tab, with **Android** and **iOS** sections, and documents the two iOS device features for public customers.

### New pages
- **Android devices** — QA Wolf runs Android tests on ephemeral emulators provisioned fresh per run.
- **iOS devices** — overview of real-device testing (shared pool + app resigning) and when to reach for the two features below.
- **Allowlisted devices (iOS)** — for features that don't work on a resigned app (push notifications, universal links). Covers signing the app for QA Wolf's devices, injecting QA Wolf instrumentation (Fastlane action / script), targeting allowlisted devices, and disabling resigning via the `qawolf:disableResigning` capability.
- **Private devices (iOS)** — devices dedicated to a single team for MDM testing and persistence across runs, with an allowlisted-vs-private comparison.

### Navigation
`Features → Mobile → { Android, iOS }` added to `docs.json`.

## Source
Adapted from the internal Allowlisted Devices and Private Devices feature docs.

## Internal info deliberately excluded
Device UDIDs, customer names, MDS configuration, internal repos (`ios-agent`, `deploy-production`), instrumentation library internals, device-selection strategy, Apple Pay (marked not-yet-public), and internal Notion/Slack links.

## Notes for review
- Device targeting is documented using the internal `meta: { ..., targetDevices }` object (`"Allowlisted Device"` / `"Team Dedicated Device"`), per request. Note this differs from the existing public `target` string literals documented in the [Target Literals reference](qawolf/libraries/flows/api-reference/index.mdx) (e.g. `"iOS - iPhone 15 (iOS 26) (allowlisted)"`). Worth deciding whether to reconcile the two in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)