### PR TITLE
docs: correct deploy_success response contract for dedup behavior (WIZ-10935) [superseded by #170]

### DIFF
--- a/qawolf/deploy-success.mdx
+++ b/qawolf/deploy-success.mdx
@@ -68,7 +68,13 @@ All fields are optional.
 }
 ```
 
-`results` is an array of matched triggers. Each entry contains either `created_suite_id` if a run was created, `duplicate_suite_id` if a run for this SHA already exists, or `failure_reason` if the run could not be created.
+`results` is an array of matched triggers. Each entry contains either `created_suite_id` if a run was created, or `failure_reason` if the run could not be created.
+
+A `created_suite_id` is returned even when the deployment duplicates one QA Wolf is already handling. Deduplication is settled after this response is sent, so the synchronous response does not report it. To find out whether your run was superseded by a duplicate, poll [CI greenlight](/qawolf/v0-ci-greenlight) and compare `relevantRunId` with `rootRunId` (see [Superseding logic](/qawolf/v0-ci-greenlight#superseding-logic)).
+
+<Note>
+  Retrying `deploy_success` for the same `sha` after deduplication has settled can return `duplicate_suite_id` in place of `created_suite_id`. The first response for a deployment always returns `created_suite_id`.
+</Note>
 
 ## Response codes
 


### PR DESCRIPTION
Corrects the `deploy_success` response contract for the dedup change (WIZ-10705 / WIZ-10728): a suite is pre-allocated and `created_suite_id` is returned even for deduplicated triggers. Dedup is now surfaced via green-light supersession, not `duplicate_suite_id` in the synchronous response. `duplicate_suite_id` is scoped to same-`sha` retries after dedup has settled.

The ticket's "no public page documents the response contract" was stale; `qawolf/deploy-success.mdx` already did. Canonical home stays here, no new page.

**Draft, do not merge.** Gated on the rollout / WIZ-10891 announcement (flag default off).

WIZ-10935
