### PR TITLE
Add @qawolf/pom library documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -382,6 +382,24 @@
             ]
           },
           {
+            "group": "@qawolf/pom",
+            "icon": "sitemap",
+            "pages": [
+              {
+                "group": "API Reference",
+                "pages": [
+                  "qawolf/libraries/pom/api-reference/index"
+                ]
+              },
+              {
+                "group": "Troubleshooting",
+                "pages": [
+                  "qawolf/libraries/pom/troubleshooting"
+                ]
+              }
+            ]
+          },
+          {
             "group": "@qawolf/testkit",
             "icon": "wrench",
             "pages": [

--- a/qawolf/libraries/pom/api-reference/index.mdx
+++ b/qawolf/libraries/pom/api-reference/index.mdx
@@ -1,0 +1,213 @@
+---
+title: "API Reference"
+description: "API reference for @qawolf/pom — page object base classes, the page registry, typed construction, and page hooks."
+sidebarTitle: "API Reference"
+---
+
+`@qawolf/pom` provides Page Object Model (POM) infrastructure for
+[Playwright](https://playwright.dev): base classes for page objects, a central
+registry that lets page objects construct one another without circular imports,
+and automatic installation of popup and route-interception hooks.
+
+## Requirements
+
+- **Node.js** `>=22.22`
+- **ES modules** — the package is ESM-only (`"type": "module"`). Import it from
+  ESM code and use explicit `.js` specifiers in relative imports.
+- **Peer dependencies**
+  - `@qawolf/flows` — used by `EntryPointPageObject` to launch the browser.
+  - `playwright` — for the `Page` / `Locator` types your page objects use.
+
+## Install
+
+```sh
+npm install @qawolf/pom
+```
+
+## Defining a page object
+
+Extend `BasePageObject`. It stores the Playwright `Page` (available as
+`this.page`) and provides `this.create(...)` for constructing other page
+objects. Keep selectors in a private `locators` getter.
+
+```ts
+import { BasePageObject } from "@qawolf/pom";
+
+export class LoginPage extends BasePageObject {
+  private get locators() {
+    return {
+      email: this.page.getByLabel("Email"),
+      password: this.page.getByLabel("Password"),
+      submit: this.page.getByRole("button", { name: "Sign in" }),
+    } as const;
+  }
+
+  async signIn(email: string, password: string) {
+    await this.locators.email.fill(email);
+    await this.locators.password.fill(password);
+    await this.locators.submit.click();
+    return this.create("DashboardPage");
+  }
+}
+```
+
+## The page registry
+
+### Registering
+
+Create one module that registers every page object, and import it for its side
+effects **before** you construct any page object. Register lazily with a module
+loader so a page object's module is only loaded when it is first used:
+
+```ts
+// register-pages.ts
+import { registerPage } from "@qawolf/pom";
+
+registerPage("LoginPage", () => import("./pages/login-page.js"));
+registerPage("DashboardPage", () => import("./pages/dashboard-page.js"));
+```
+
+The loader must resolve to a module that exports the class under the **same
+name** it was registered with. Eager registration also works when you already
+hold the class value:
+
+```ts
+import { LoginPage } from "./pages/login-page.js";
+
+registerPage("LoginPage", LoginPage);
+```
+
+### Constructing
+
+`createPage` builds a registered page object for a given `Page`. Import the
+registration module first so the registry is populated:
+
+```ts
+import "./register-pages.js";
+import { createPage } from "@qawolf/pom";
+
+const loginPage = await createPage("LoginPage", page);
+await loginPage.signIn("user@example.com", "hunter2");
+```
+
+Inside a page object, use the protected `this.create(...)` instead — it shares
+the current `Page` and routes through the same registry, which is what lets
+page objects reference each other without importing each other's classes as
+values (avoiding circular imports). Use `import type` only for annotations:
+
+```ts
+import { BasePageObject } from "@qawolf/pom";
+import type { SettingsPage } from "./settings-page.js";
+
+export class DashboardPage extends BasePageObject {
+  async openSettings(): Promise<SettingsPage> {
+    await this.page.getByRole("link", { name: "Settings" }).click();
+    return this.create("SettingsPage");
+  }
+}
+```
+
+`create` / `createPage` are async because lazily registered modules load on
+first use.
+
+### Typing `this.create(...)`
+
+By default `this.create("LoginPage")` returns `any`. Augment the
+`RegisteredPages` interface — declared for exactly this purpose — to make the
+name-to-type mapping known, and `create` becomes fully typed. This is
+incremental: names you don't list keep the `any` fallback.
+
+```ts
+import type { LoginPage } from "./pages/login-page.js";
+import type { DashboardPage } from "./pages/dashboard-page.js";
+
+declare module "@qawolf/pom" {
+  interface RegisteredPages {
+    LoginPage: LoginPage;
+    DashboardPage: DashboardPage;
+  }
+}
+```
+
+Now `await this.create("LoginPage")` is typed as `LoginPage`.
+
+## Entry points and page hooks
+
+An **entry point** is the page object that owns browser startup. Extend
+`EntryPointPageObject` and expose a `create()` that launches the browser
+(`initializeBrowser`), builds the instance (`createFromPage`), and installs
+page hooks:
+
+```ts
+import { EntryPointPageObject } from "@qawolf/pom";
+
+export class AppEntryPoint extends EntryPointPageObject {
+  static async create(): Promise<AppEntryPoint> {
+    const page = await AppEntryPoint.initializeBrowser();
+    const entryPoint = AppEntryPoint.createFromPage(page);
+    await entryPoint.installPageHooks();
+    return entryPoint;
+  }
+
+  async openLogin() {
+    await this.goto("/login");
+    return this.create("LoginPage");
+  }
+}
+```
+
+A page object can own popups to auto-dismiss or routes to intercept by
+overriding `popupHandlers()` / `routeInterceptors()` on its class:
+
+```ts
+import { BasePageObject, type PopupHandlerDef } from "@qawolf/pom";
+
+export class CookieBannerPage extends BasePageObject {
+  override popupHandlers(): PopupHandlerDef[] {
+    return [
+      {
+        name: "cookie-banner",
+        trigger: this.page.getByRole("button", { name: "Accept cookies" }),
+        dismiss: async () => {
+          await this.page
+            .getByRole("button", { name: "Accept cookies" })
+            .click();
+        },
+      },
+    ];
+  }
+}
+```
+
+`installPageHooks()` collects these across **every** registered page object,
+not just the entry point. Overrides are detected by an own-property check on the
+registered class's prototype, so declare `popupHandlers()` /
+`routeInterceptors()` directly on the class you register — an override inherited
+from a base class is not picked up.
+
+When registering lazily, pass `{ providesPageHooks: false }` for page objects
+you know declare no hooks, so hook installation can skip loading their modules:
+
+```ts
+registerPage("StaticPage", () => import("./pages/static-page.js"), {
+  providesPageHooks: false,
+});
+```
+
+## Exports
+
+| Export | Description |
+| --- | --- |
+| `BasePageObject` | Base class for page objects. Holds `this.page`; provides `this.create(name)` and the static `createFromPage(page)` factory. |
+| `SubPageObject` | Base class for a page object scoped to a parent region/component. |
+| `EntryPointPageObject` | Base class for the entry point; owns browser launch (`initializeBrowser`), `goto`, and `installPageHooks`. |
+| `registerPage(name, classOrLoader, options?)` | Register a page object by name, eagerly (class) or lazily (`() => import(...)`). |
+| `createPage(name, page)` | Construct a registered page object for a `Page`. Returns a promise. |
+| `getRegisteredPopupHandlers(page)` / `getRegisteredRouteInterceptors(page)` | Collect hook definitions from all registered page objects (used by `installPageHooks`). |
+| `PopupHandler` | Manages add/remove of popup handlers on a page. |
+| `NetworkMonitor` | Observes network activity and surfaces `NetworkError`s. |
+| `RegisteredPages` | Empty interface you augment to type `create(name)`. |
+| `PopupHandlerDef`, `RouteInterceptorDef`, `PageSetupOptions` | Hook and setup types. |
+| `callPlatformAPI` | Client for the QA Wolf platform API. |
+| `assertPricesClose`, `moneyToNumber`, `numberToMoney` | Money/price test-data helpers. |
+| `reportCleanupFailed`, `reportCleanupFailure` | Report failures from test cleanup steps. |

--- a/qawolf/libraries/pom/api-reference/index.mdx
+++ b/qawolf/libraries/pom/api-reference/index.mdx
@@ -203,7 +203,6 @@ registerPage("StaticPage", () => import("./pages/static-page.js"), {
 | `EntryPointPageObject` | Base class for the entry point; owns browser launch (`initializeBrowser`), `goto`, and `installPageHooks`. |
 | `registerPage(name, classOrLoader, options?)` | Register a page object by name, eagerly (class) or lazily (`() => import(...)`). |
 | `createPage(name, page)` | Construct a registered page object for a `Page`. Returns a promise. |
-| `getRegisteredPopupHandlers(page)` / `getRegisteredRouteInterceptors(page)` | Collect hook definitions from all registered page objects (used by `installPageHooks`). |
 | `PopupHandler` | Manages add/remove of popup handlers on a page. |
 | `NetworkMonitor` | Observes network activity and surfaces `NetworkError`s. |
 | `RegisteredPages` | Empty interface you augment to type `create(name)`. |

--- a/qawolf/libraries/pom/troubleshooting.mdx
+++ b/qawolf/libraries/pom/troubleshooting.mdx
@@ -1,0 +1,71 @@
+---
+title: "POM Troubleshooting"
+description: "Troubleshoot common issues when using @qawolf/pom, including unregistered pages, duplicate registrations, and stale page-hook flags."
+sidebarTitle: "Troubleshooting"
+---
+
+## `Unknown page: <name>` When Calling `create`
+
+Cause: The module that calls `registerPage` for that name has not been imported,
+so the registry is empty for it.
+
+Check:
+
+- the workspace's `register-pages` module is side-effect imported before any
+  `create(name)` / `createPage(name, ...)` call
+- the name passed to `create` exactly matches the name passed to `registerPage`
+
+## `Page "<name>" is already registered.`
+
+Cause: `registerPage` was called twice for the same name. The registry throws on
+a duplicate key rather than silently overwriting.
+
+Check:
+
+- the name is registered in exactly one place
+- two page objects are not registered under the same name
+
+## A Page Object's Popup Or Route Hook Never Runs
+
+Cause: Page hooks are collected by an own-property check on the **registered**
+class's prototype, so an override inherited from a base class is not detected.
+
+Check:
+
+- `popupHandlers()` / `routeInterceptors()` is declared directly on the class
+  passed to `registerPage`, not only on a base class it extends
+- the entry point calls `installPageHooks()` before navigating
+
+## `providesPageHooks: false` Entry Throws On Load
+
+Cause: A page object registered with `{ providesPageHooks: false }` later grew a
+`popupHandlers()` / `routeInterceptors()` override. Loading it throws so the
+stale flag surfaces instead of silently skipping hook installation.
+
+Check:
+
+- drop `{ providesPageHooks: false }` from that registration so its hooks are
+  installed
+
+## `this.create("X")` Is Typed As `any`
+
+Cause: The name is not present in the `RegisteredPages` map.
+
+Check:
+
+- the workspace augments `RegisteredPages` (via `declare module "@qawolf/pom"`)
+  with an `X: X` entry
+- the augmentation module is included in the TypeScript program
+
+## Two Registries / Pages Invisible To Each Other
+
+Cause: More than one copy of `@qawolf/pom` resolved at runtime. The registry is
+module-level state, so each copy has its own — a page registered through one is
+invisible to the other.
+
+Check:
+
+- a single installed copy of `@qawolf/pom` resolves at runtime (no duplicate in
+  a nested `node_modules`)
+- workspace code does not mix `@qawolf/pom` with a locally vendored copy of the
+  POM library

--- a/qawolf/libraries/pom/troubleshooting.mdx
+++ b/qawolf/libraries/pom/troubleshooting.mdx
@@ -36,11 +36,13 @@ Check:
   passed to `registerPage`, not only on a base class it extends
 - the entry point calls `installPageHooks()` before navigating
 
-## `providesPageHooks: false` Entry Throws On Load
+## `providesPageHooks: false` Contradicts The Class
 
-Cause: A page object registered with `{ providesPageHooks: false }` later grew a
-`popupHandlers()` / `routeInterceptors()` override. Loading it throws so the
-stale flag surfaces instead of silently skipping hook installation.
+Cause: A page object registered with `{ providesPageHooks: false }` declares a
+`popupHandlers()` / `routeInterceptors()` override. The registry throws so the
+stale flag surfaces instead of silently skipping hook installation — at
+`registerPage` time for an eagerly registered class, on first load for a lazy
+one.
 
 Check:
 


### PR DESCRIPTION
## Overview

Adds documentation for the new `@qawolf/pom` package (Page Object Model infrastructure for Playwright) under **References → @qawolf/pom**, mirroring the structure of the other `@qawolf/*` libraries:

- **API Reference** (`qawolf/libraries/pom/api-reference/index`) — requirements, install, defining page objects, the page registry (lazy/eager registration + construction), typing `this.create` via `RegisteredPages` augmentation, entry points, page hooks, and an exports table.
- **Troubleshooting** (`qawolf/libraries/pom/troubleshooting`) — unregistered pages, duplicate registration, undetected inherited hooks, the `providesPageHooks: false` contradiction, untyped `create`, and the one-registry-per-process gotcha.

Registered both pages in `docs.json` navigation. The package's README on npm links here (`docs.qawolf.com/qawolf/libraries/pom`).

Pairs with the `@qawolf/pom` package PR in qawolf/platform (#28522).