### PR TITLE
docs(cli): use <env_id> placeholder and show where to find the ID

### DIFF
--- a/qawolf/libraries/cli/api-reference/commands.mdx
+++ b/qawolf/libraries/cli/api-reference/commands.mdx
@@ -40,12 +40,12 @@ Manages and runs QA Wolf flows.
 
 ### `flows run [pattern]`
 
-Runs flows matching `[pattern]`, or every flow when omitted. The default pattern matches `**/*.flow.{ts,js}` in the current working directory and in `.qawolf/<env>/` subdirectories.
+Runs flows matching `[pattern]`, or every flow when omitted. The default pattern matches `**/*.flow.{ts,js}` in the current working directory and in `.qawolf/<env_id>/` subdirectories.
 
 ```bash
 qawolf flows run
 qawolf flows run "flows/checkout/**"
-qawolf flows run checkout --env staging --headed
+qawolf flows run checkout --env <env_id> --headed
 ```
 
 Options:
@@ -61,7 +61,7 @@ Options:
 - `--har-content <mode>` — `omit` or `full`. `full` includes response bodies and uses more memory. Default: `omit`.
 - `--output-dir <path>` — directory for artifacts. Default: `qawolf-output`.
 - `--headed` — show the browser window instead of running headless. Default: `false`.
-- `--env <env>` — environment ID. When set, missing flows are pulled before the run.
+- `--env <env_id>` — environment ID. When set, missing flows are pulled before the run. See [where to find it](/qawolf/local-execution/pull-flows#pull-an-environment).
 
 Exit codes: `0` when all flows pass, `1` when one or more flows fail, `2` for invalid arguments or an unrecognized flow target. See [Exit codes](/qawolf/libraries/cli/api-reference/index#exit-codes).
 
@@ -81,18 +81,18 @@ Options:
 
 ### `flows pull`
 
-Downloads an environment's flows into the local `.qawolf/<env>/` cache.
+Downloads an environment's flows into the local `.qawolf/<env_id>/` cache.
 
 ```bash
-qawolf flows pull --env staging
-qawolf flows pull --env 4e9c... --out ./snapshot
-qawolf flows pull --env staging --yes
+qawolf flows pull --env <env_id>
+qawolf flows pull --env <env_id> --out ./snapshot
+qawolf flows pull --env <env_id> --yes
 ```
 
 Options:
 
-- `--env <env>` — required. The environment ID to pull from.
-- `--out <path>` — destination directory. Defaults to `.qawolf/<env>/`.
+- `--env <env_id>` — required. The environment ID to pull from. See [where to find it](/qawolf/local-execution/pull-flows#pull-an-environment).
+- `--out <path>` — destination directory. Defaults to `.qawolf/<env_id>/`.
 - `--yes` — overwrite locally-modified files without prompting. Default: `false`.
 
 ## `install`
@@ -157,13 +157,13 @@ Triggers and manages runs on the QA Wolf platform. Unlike the local execution co
 Creates a run on the QA Wolf platform.
 
 ```bash
-qawolf run create --environment-id <id>
-qawolf run create --environment-id <id> --flow-ids <id>... --environment-variables KEY=VALUE
+qawolf run create --environment-id <env_id>
+qawolf run create --environment-id <env_id> --flow-ids <flow_id>... --environment-variables KEY=VALUE
 ```
 
 Options:
 
-- `--environment-id <value>` — the ID of the environment to run.
+- `--environment-id <env_id>` — the ID of the environment to run. See [where to find it](/qawolf/local-execution/pull-flows#pull-an-environment).
 - `--environment-variables <KEY=VALUE...>` — environment variables to set for the run.
-- `--flow-ids <values...>` — limit the run to specific flow IDs.
+- `--flow-ids <flow_id>...` — limit the run to specific flow IDs.
 - `--ignore-rules` — ignore the environment's run rules.

--- a/qawolf/libraries/cli/api-reference/index.mdx
+++ b/qawolf/libraries/cli/api-reference/index.mdx
@@ -19,9 +19,11 @@ Example invocation:
 
 ```bash
 qawolf auth login
-qawolf flows pull --env <env>
+qawolf flows pull --env <env_id>
 qawolf flows run
 ```
+
+Find the environment ID in the app URL — see [Pull flows](/qawolf/local-execution/pull-flows#pull-an-environment).
 
 ## Global Options
 

--- a/qawolf/libraries/cli/troubleshooting.mdx
+++ b/qawolf/libraries/cli/troubleshooting.mdx
@@ -31,7 +31,7 @@ Cause: The API key is valid but does not have access to the requested environmen
 Check:
 
 - the key was issued for a workspace that contains this environment
-- the environment ID matches one returned by the platform
+- the environment ID matches one returned by the platform — see [where to find it](/qawolf/local-execution/pull-flows#pull-an-environment)
 
 ## Could Not Reach The QA Wolf API
 
@@ -49,7 +49,7 @@ Cause: The signed URL the CLI received from the platform has expired before the 
 
 Check:
 
-- re-run `qawolf flows pull --env <env>` to fetch a fresh link
+- re-run `qawolf flows pull --env <env_id>` to fetch a fresh link
 - network conditions are not slowing the download past the link's expiration window
 
 ## Android SDK Not Found

--- a/qawolf/local-execution/authenticate.mdx
+++ b/qawolf/local-execution/authenticate.mdx
@@ -63,7 +63,7 @@ CI environments cannot prompt for input. Set the `QAWOLF_API_KEY` environment va
 
 ```bash
 export QAWOLF_API_KEY=<your-api-key>
-qawolf flows pull --env staging
+qawolf flows pull --env <env_id>
 ```
 
 The CLI prefers `QAWOLF_API_KEY` over any credential stored by `qawolf auth login`, so the same machine can switch between accounts by setting or unsetting the variable.

--- a/qawolf/local-execution/install-dependencies.mdx
+++ b/qawolf/local-execution/install-dependencies.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Install dependencies"
 icon: "download"
 ---
 
-[`qawolf flows run --env <env>`](/qawolf/local-execution/run-flows-locally) installs npm dependencies and Playwright browsers automatically before its first run, so web-only users rarely invoke `qawolf install` directly. Android dependencies are not installed during a run; run `qawolf install android` before running Android flows. Also reach for `qawolf install` to install ahead of time (for example, to warm a CI cache between the checkout step and the run step) or when running flows from a [local-only project](/qawolf/local-execution/set-up-a-project).
+[`qawolf flows run --env <env_id>`](/qawolf/local-execution/run-flows-locally) installs npm dependencies and Playwright browsers automatically before its first run, so web-only users rarely invoke `qawolf install` directly. Android dependencies are not installed during a run; run `qawolf install android` before running Android flows. Also reach for `qawolf install` to install ahead of time (for example, to warm a CI cache between the checkout step and the run step) or when running flows from a [local-only project](/qawolf/local-execution/set-up-a-project).
 
 ## Install everything the project needs
 

--- a/qawolf/local-execution/pull-flows.mdx
+++ b/qawolf/local-execution/pull-flows.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Pull flows"
 icon: "cloud-download"
 ---
 
-For most workflows, [`qawolf flows run --env <env>`](/qawolf/local-execution/run-flows-locally) is enough — it pulls the environment's flows for you when they are not already cached locally. Reach for `qawolf flows pull` when you want to download the flow files without running them: to inspect them, commit them to a repository, or refresh a stale cache.
+For most workflows, [`qawolf flows run --env <env_id>`](/qawolf/local-execution/run-flows-locally) is enough — it pulls the environment's flows for you when they are not already cached locally. Reach for `qawolf flows pull` when you want to download the flow files without running them: to inspect them, commit them to a repository, or refresh a stale cache.
 
 <Check>
   Authenticate the CLI first. See [Authenticate the QA Wolf CLI](/qawolf/local-execution/authenticate).
@@ -15,19 +15,19 @@ For most workflows, [`qawolf flows run --env <env>`](/qawolf/local-execution/run
 
 <Steps>
   <Step>
-    Find the environment's ID in your QA Wolf workspace under **Workspace settings → Environments**.
+    Find the environment's ID in the QA Wolf app. Open **Workspace settings → Environments** and select the environment. Copy the `id` query parameter from the page URL: `https://app.qawolf.com/<team_slug>/settings/environments?id=<env_id>`. Use that value, not the environment's display name.
   </Step>
   <Step>
     Pull the flows:
 
     ```bash
-    qawolf flows pull --env staging
+    qawolf flows pull --env <env_id>
     ```
 
-    The CLI writes flows to `.qawolf/staging/` by default. To use a different destination, pass `--out`:
+    The CLI writes flows to `.qawolf/<env_id>/` by default. To use a different destination, pass `--out`:
 
     ```bash
-    qawolf flows pull --env staging --out ./snapshot
+    qawolf flows pull --env <env_id> --out ./snapshot
     ```
   </Step>
   <Step>
@@ -41,7 +41,7 @@ For most workflows, [`qawolf flows run --env <env>`](/qawolf/local-execution/run
 
 ## What `pull` writes
 
-Inside `.qawolf/<env>/`, the CLI stores:
+Inside `.qawolf/<env_id>/`, the CLI stores:
 
 - the flow source files
 - a manifest tracking what was pulled and when
@@ -50,10 +50,10 @@ Inside `.qawolf/<env>/`, the CLI stores:
 
 ## Refresh a pulled environment
 
-Run `qawolf flows pull --env <env>` again. The CLI prompts before overwriting any file that has been modified locally. To skip the prompt and overwrite, pass `--yes`:
+Run `qawolf flows pull --env <env_id>` again. The CLI prompts before overwriting any file that has been modified locally. To skip the prompt and overwrite, pass `--yes`:
 
 ```bash
-qawolf flows pull --env staging --yes
+qawolf flows pull --env <env_id> --yes
 ```
 
 ## List flows on the platform

--- a/qawolf/local-execution/run-flows-locally.mdx
+++ b/qawolf/local-execution/run-flows-locally.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Run flows locally"
 icon: "play"
 ---
 
-`qawolf flows run --env <env>` is the recommended path. It runs your team's flows from the local `.qawolf/<env>/` cache, pulling them first only if they are not already cached locally, then installs the npm dependencies and Playwright browsers they need and runs them. Android flows require installing the Android tooling first with `qawolf install android`. See [Install dependencies](/qawolf/local-execution/install-dependencies).
+`qawolf flows run --env <env_id>` is the recommended path. It runs your team's flows from the local `.qawolf/<env_id>/` cache, pulling them first only if they are not already cached locally, then installs the npm dependencies and Playwright browsers they need and runs them. Android flows require installing the Android tooling first with `qawolf install android`. See [Install dependencies](/qawolf/local-execution/install-dependencies).
 
 <Check>
   Authenticate the CLI first. See [Authenticate the QA Wolf CLI](/qawolf/local-execution/authenticate).
@@ -15,23 +15,23 @@ icon: "play"
 
 <Steps>
   <Step>
-    Find the environment's ID in your QA Wolf workspace under **Workspace settings → Environments**.
+    Find the environment's ID in the QA Wolf app. Open **Workspace settings → Environments** and select the environment. Copy the `id` query parameter from the page URL: `https://app.qawolf.com/<team_slug>/settings/environments?id=<env_id>`. Use that value, not the environment's display name.
   </Step>
   <Step>
     From any directory, run:
 
     ```bash
-    qawolf flows run --env staging
+    qawolf flows run --env <env_id>
     ```
 
     The CLI:
 
-    1. checks the local `.qawolf/staging/` cache, and pulls the environment's flows only if they are not already cached
+    1. checks the local `.qawolf/<env_id>/` cache, and pulls the environment's flows only if they are not already cached
     2. loads the environment's `.env` file
     3. installs the npm dependencies and Playwright browsers the flows need
     4. runs every flow
 
-    To refresh the local cache against the platform, run `qawolf flows pull --env staging`. See [Pull your team's flows](/qawolf/local-execution/pull-flows).
+    To refresh the local cache against the platform, run `qawolf flows pull --env <env_id>`. See [Pull your team's flows](/qawolf/local-execution/pull-flows).
   </Step>
 </Steps>
 
@@ -40,18 +40,18 @@ icon: "play"
 Pass a glob pattern to limit which flows run:
 
 ```bash
-qawolf flows run --env staging "checkout/**"
-qawolf flows run --env staging "src/flows/login.flow.ts"
+qawolf flows run --env <env_id> "checkout/**"
+qawolf flows run --env <env_id> "src/flows/login.flow.ts"
 ```
 
-With `--env`, patterns are matched against the pulled cache under `.qawolf/<env>/`. Without `--env`, patterns are matched against both the current directory and the pulled cache.
+With `--env`, patterns are matched against the pulled cache under `.qawolf/<env_id>/`. Without `--env`, patterns are matched against both the current directory and the pulled cache.
 
 ## Watch the browser
 
 Pass `--headed` to see the browser window during a web run:
 
 ```bash
-qawolf flows run --env staging --headed
+qawolf flows run --env <env_id> --headed
 ```
 
 `--headed` does not apply to Android flows.
@@ -61,7 +61,7 @@ qawolf flows run --env staging --headed
 By default, no video or trace is recorded. To keep artifacts only when a flow fails, set the mode to `retain-on-failure`:
 
 ```bash
-qawolf flows run --env staging --video retain-on-failure --trace retain-on-failure
+qawolf flows run --env <env_id> --video retain-on-failure --trace retain-on-failure
 ```
 
 Artifacts land in `qawolf-output/` (or the directory set by `--output-dir`).
@@ -69,7 +69,7 @@ Artifacts land in `qawolf-output/` (or the directory set by `--output-dir`).
 To record HAR files of network traffic:
 
 ```bash
-qawolf flows run --env staging --har retain-on-failure
+qawolf flows run --env <env_id> --har retain-on-failure
 ```
 
 By default the HAR captures headers and timing only. To include response bodies, pass `--har-content full`. Response bodies use significantly more memory and disk.
@@ -77,7 +77,7 @@ By default the HAR captures headers and timing only. To include response bodies,
 ## Retry failing flows
 
 ```bash
-qawolf flows run --env staging --retries 2
+qawolf flows run --env <env_id> --retries 2
 ```
 
 The CLI retries each failing flow up to the given number of times. A flow that passes on retry is counted as a pass for exit-code purposes.
@@ -85,7 +85,7 @@ The CLI retries each failing flow up to the given number of times. A flow that p
 ## Stop after the first failure
 
 ```bash
-qawolf flows run --env staging --bail
+qawolf flows run --env <env_id> --bail
 ```
 
 `--bail` is useful when iterating on a single flow and you want to fail fast.
@@ -93,7 +93,7 @@ qawolf flows run --env staging --bail
 ## Run web flows in parallel
 
 ```bash
-qawolf flows run --env staging --workers 4
+qawolf flows run --env <env_id> --workers 4
 ```
 
 `--workers` controls how many web flows run concurrently. Android flows must run with `--workers 1` — the CLI errors out if Android flows are selected with a higher value.
@@ -101,13 +101,13 @@ qawolf flows run --env staging --workers 4
 ## Write a JUnit XML report
 
 ```bash
-qawolf flows run --env staging --junit
+qawolf flows run --env <env_id> --junit
 ```
 
 The CLI writes a JUnit XML report to `qawolf-output/junit-report.xml` (or under the directory set by `--output-dir`). Pass an explicit path to override the default:
 
 ```bash
-qawolf flows run --env staging --junit ./reports/results.xml
+qawolf flows run --env <env_id> --junit ./reports/results.xml
 ```
 
 The XML report is written alongside the console output and is independent of `--json` and `--agent`.


### PR DESCRIPTION
Closes WIZ-11203.

## What

- Replace friendly env names (`--env staging`) in every CLI example with the `<env_id>` placeholder, so it reads as an opaque ID rather than a name that only works by accident.
- Apply `<env_id>` consistently across examples, flag descriptions, and `.qawolf/<env_id>/` cache paths.
- Rewrite the "find the environment's ID" step in the guide pages: the ID is the `id` **query parameter** in the Workspace settings URL (`app.qawolf.com/<team_slug>/settings/environments?id=<env_id>`), not the visible alias.
- Cross-link the reference and troubleshooting pages to that canonical "where to find it" section.
- Align the `run create` option names (`--environment-id <env_id>`, `--flow-ids <flow_id>...`) with its own examples.

## Why

A customer hit a 400 pulling flows because the docs showed a friendly name where the API expects the environment ID. This is docs-only; it does not rename any CLI flag.

## Out of scope

- Selecting from a list of environments when no ID is given — deferred to a separate ticket per WIZ-11203.
- Unifying the flag names (`--env` vs `--environment-id`) — that's a CLI change, not docs.

## Review

Passed a two-axis review (standards + spec against WIZ-11203); the flagged findings were applied in the second commit-worth of edits before this PR.