### PR TITLE
docs(android): document the supported app installation formats

### DIFF
--- a/qawolf/libraries/flows/api-reference/android.mdx
+++ b/qawolf/libraries/flows/api-reference/android.mdx
@@ -252,8 +252,6 @@ QA Wolf installs your app from either a local path or a URL, in either the `.apk
 | local path | `.apk`, `.aab` | installs the build, converting a `.aab` to installable APKs first |
 | URL | `.apk`, `.aab` | downloads the build, then the same as above |
 
-In every case QA Wolf reads the build's `versionName` and `versionCode` and writes them to the run log, so you can confirm which build a run tested against.
-
 ```ts
 // a build your CI uploaded, or a path in your repository
 await launch({ app: { path: "apps/android/app.aab" } });
@@ -262,10 +260,24 @@ await launch({ app: { path: "apps/android/app.aab" } });
 await launch({ app: { url: "https://builds.example.com/app.apk?token=abc" } });
 ```
 
+In every case QA Wolf reads the build's `versionName` and `versionCode` and writes them to the run log, so you can confirm which build a run tested against:
+
+```
+App version (apps/android/app.aab): versionName=4.89.1, versionCode=43566
+```
+
 A URL is only fetched by QA Wolf when its path ends in `.apk` or `.aab`. A query string does not change that, so a signed or expiring download link works as long as the path keeps the extension. Anything else, such as a share page or a download endpoint that names the file elsewhere, is passed to the driver untouched.
 
+You can also install an app yourself over adb, which skips everything above:
+
+```ts
+// -r to replace an existing install, and a timeout large enough for the transfer
+await device.adb(["install-multiple", "-r", ...splitPaths], { timeout: 600_000 });
+await launch({ appPackage: "com.example.app", appActivity: ".MainActivity" });
+```
+
 <Note>
-  Prefer handing us the `.apk` or `.aab`. You can install an app yourself with `device.adb("install-multiple ...")`, but then you own everything that comes with it: choosing the right split APKs for the device, reading the manifest for the launcher activity, and sizing the transfer. Passing `app` gets all of that handled for you.
+  Prefer handing us the `.apk` or `.aab`. Installing over adb means you own everything that comes with it: choosing the right split APKs for the device, reading the manifest for the launcher activity, and sizing the transfer. Passing `app` gets all of that handled for you.
 </Note>
 
 ### Advanced Appium capabilities

--- a/qawolf/libraries/flows/api-reference/android.mdx
+++ b/qawolf/libraries/flows/api-reference/android.mdx
@@ -247,14 +247,20 @@ await launch({
 
 QA Wolf installs your app from either a local path or a URL, in either the `.apk` or `.aab` format.
 
-| Source | Format | What QA Wolf does |
+| Source | Formats | What QA Wolf does |
 | --- | --- | --- |
-| local path | `.apk` | installs it as-is |
-| local path | `.aab` | converts it to installable APKs, then installs |
-| URL | `.apk` | downloads it, then installs |
-| URL | `.aab` | downloads it, converts it, then installs |
+| local path | `.apk`, `.aab` | installs the build, converting a `.aab` to installable APKs first |
+| URL | `.apk`, `.aab` | downloads the build, then the same as above |
 
 In every case QA Wolf reads the build's `versionName` and `versionCode` and writes them to the run log, so you can confirm which build a run tested against.
+
+```ts
+// a build your CI uploaded, or a path in your repository
+await launch({ app: { path: "apps/android/app.aab" } });
+
+// a link QA Wolf can fetch, including a signed or expiring one
+await launch({ app: { url: "https://builds.example.com/app.apk?token=abc" } });
+```
 
 A URL is only fetched by QA Wolf when its path ends in `.apk` or `.aab`. A query string does not change that, so a signed or expiring download link works as long as the path keeps the extension. Anything else, such as a share page or a download endpoint that names the file elsewhere, is passed to the driver untouched.
 

--- a/qawolf/libraries/flows/api-reference/android.mdx
+++ b/qawolf/libraries/flows/api-reference/android.mdx
@@ -243,6 +243,25 @@ await launch({
   If `app` is present but does not resolve to a value, launch does not fall back to `RUN_INPUT_PATH`.
 </Note>
 
+### Supported app formats
+
+QA Wolf installs your app from either a local path or a URL, in either the `.apk` or `.aab` format.
+
+| Source | Format | What QA Wolf does |
+| --- | --- | --- |
+| local path | `.apk` | installs it as-is |
+| local path | `.aab` | converts it to installable APKs, then installs |
+| URL | `.apk` | downloads it, then installs |
+| URL | `.aab` | downloads it, converts it, then installs |
+
+In every case QA Wolf reads the build's `versionName` and `versionCode` and writes them to the run log, so you can confirm which build a run tested against.
+
+A URL is only fetched by QA Wolf when its path ends in `.apk` or `.aab`. A query string does not change that, so a signed or expiring download link works as long as the path keeps the extension. Anything else, such as a share page or a download endpoint that names the file elsewhere, is passed to the driver untouched.
+
+<Note>
+  Prefer handing us the `.apk` or `.aab`. You can install an app yourself with `device.adb("install-multiple ...")`, but then you own everything that comes with it: choosing the right split APKs for the device, reading the manifest for the launcher activity, and sizing the transfer. Passing `app` gets all of that handled for you.
+</Note>
+
 ### Advanced Appium capabilities
 
 The named launch options above cover the most common settings. For anything else, use the `capabilities` escape hatch: its entries are spread into the underlying [webdriver.io `remote`](https://webdriver.io/docs/api) capabilities and passed straight to the Android driver.

--- a/qawolf/libraries/flows/api-reference/android.mdx
+++ b/qawolf/libraries/flows/api-reference/android.mdx
@@ -249,8 +249,8 @@ QA Wolf installs your app from either a local path or a URL, in either the `.apk
 
 | Source | Formats | What QA Wolf does |
 | --- | --- | --- |
-| local path | `.apk`, `.aab` | prepares the build and installs it |
-| URL | `.apk`, `.aab` | downloads the build, then the same as above |
+| local path | `.apk`, `.aab` | installs the build |
+| URL | `.apk`, `.aab` | downloads the build, then installs it |
 
 ```ts
 // a build your CI uploaded, or a path in your repository
@@ -260,7 +260,7 @@ await launch({ app: { path: "apps/android/app.aab" } });
 await launch({ app: { url: "https://builds.example.com/app.apk?token=abc" } });
 ```
 
-QA Wolf logs which build a run installed, so you can confirm the version a run tested against.
+QA Wolf writes the version of the installed build to the run log, so you can confirm which build a run tested against.
 
 A URL is only fetched by QA Wolf when its path ends in `.apk` or `.aab`. A query string does not change that, so a signed or expiring download link works as long as the path keeps the extension. Anything else, such as a share page or a download endpoint that names the file elsewhere, is passed to the driver untouched.
 

--- a/qawolf/libraries/flows/api-reference/android.mdx
+++ b/qawolf/libraries/flows/api-reference/android.mdx
@@ -249,7 +249,7 @@ QA Wolf installs your app from either a local path or a URL, in either the `.apk
 
 | Source | Formats | What QA Wolf does |
 | --- | --- | --- |
-| local path | `.apk`, `.aab` | installs the build, converting a `.aab` to installable APKs first |
+| local path | `.apk`, `.aab` | prepares the build and installs it |
 | URL | `.apk`, `.aab` | downloads the build, then the same as above |
 
 ```ts
@@ -260,11 +260,7 @@ await launch({ app: { path: "apps/android/app.aab" } });
 await launch({ app: { url: "https://builds.example.com/app.apk?token=abc" } });
 ```
 
-In every case QA Wolf reads the build's `versionName` and `versionCode` and writes them to the run log, so you can confirm which build a run tested against:
-
-```
-App version (apps/android/app.aab): versionName=4.89.1, versionCode=43566
-```
+QA Wolf logs which build a run installed, so you can confirm the version a run tested against.
 
 A URL is only fetched by QA Wolf when its path ends in `.apk` or `.aab`. A query string does not change that, so a signed or expiring download link works as long as the path keeps the extension. Anything else, such as a share page or a download endpoint that names the file elsewhere, is passed to the driver untouched.
 


### PR DESCRIPTION
## Overview

Our Android app installation capabilities were not written down anywhere. Erkan asked for a table of what we support so the docs reflect it.

Adds a `Supported app formats` section to the Android flows API reference, right after `App Resolution` where the `app.path` and `app.url` resolution order is already explained.

## What it says

The four combinations that a QAE actually chooses between, which is source crossed with format:

| Source | Format |
| --- | --- |
| local path | `.apk` and `.aab` |
| URL | `.apk` and `.aab` |

Plus two things that were not documented anywhere and cost people time:

- A URL is only fetched by us when its path ends in an installable extension. A query string does not change that, so a signed or expiring link works as long as the path keeps the extension. Anything else goes to the driver untouched.
- `device.adb("install-multiple ...")` works but is not recommended, because the QAE then owns split selection, the launcher activity and the transfer size.

## Deliberately left out

`.apks` is an artifact we generate from a `.aab`, not something a QAE hands us. Listing it would read as an invitation to build one and turn an internal format into a supported input. Verified today how much work that actually is: picking the wrong base master fails with `Split null was defined multiple times`, and the right set only comes from `bundletool extract-apks` against a device spec.
