### PR TITLE
docs(pom): page objects can construct siblings by direct import (NOVA-1448)

### DIFF
--- a/qawolf/libraries/pom/api-reference/index.mdx
+++ b/qawolf/libraries/pom/api-reference/index.mdx
@@ -5,9 +5,9 @@ sidebarTitle: "API Reference"
 ---
 
 `@qawolf/pom` provides Page Object Model (POM) infrastructure for
-[Playwright](https://playwright.dev): base classes for page objects, a central
-registry that lets page objects construct one another without circular imports,
-and automatic installation of popup and route-interception hooks.
+[Playwright](https://playwright.dev): base classes for page objects, a registry
+that constructs page objects by name and collects their page hooks, and
+automatic installation of popup and route-interception hooks.
 
 ## Requirements
 
@@ -27,11 +27,14 @@ npm install @qawolf/pom
 ## Defining a page object
 
 Extend `BasePageObject`. It stores the Playwright `Page` (available as
-`this.page`) and provides `this.create(...)` for constructing other page
-objects. Keep selectors in a private `locators` getter.
+`this.page`) and provides two ways to construct another page object: the static
+`createFromPage(page)` factory on a class you imported, and `this.create(name)`
+for a registered name. Keep selectors in a private `locators` getter.
 
 ```ts
 import { BasePageObject } from "@qawolf/pom";
+
+import { DashboardPage } from "./dashboard-page.js";
 
 export class LoginPage extends BasePageObject {
   private get locators() {
@@ -46,12 +49,27 @@ export class LoginPage extends BasePageObject {
     await this.locators.email.fill(email);
     await this.locators.password.fill(password);
     await this.locators.submit.click();
-    return this.create("DashboardPage");
+    return DashboardPage.createFromPage(this.page);
   }
 }
 ```
 
+`dashboard-page.js` may import `login-page.js` back, so two page objects that
+navigate to each other can both expose the trip. What Node cannot load is a page
+object that `extend`s a class in a file importing it back — see
+[Troubleshooting](/qawolf/libraries/pom/troubleshooting).
+
 ## The page registry
+
+The registry does two things: it constructs a page object from a name, and it is
+the list `installPageHooks()` walks to collect popup handlers and route
+interceptors. A direct import replaces the first job but not the second, so a
+page object that declares `popupHandlers()` or `routeInterceptors()` needs a
+registry entry however its instances get built.
+
+Constructing by name also keeps a page object's module out of the calling file's
+import graph until the first construction, which is worth having when a
+workspace holds many page objects.
 
 ### Registering
 
@@ -91,9 +109,8 @@ await loginPage.signIn("user@example.com", "hunter2");
 ```
 
 Inside a page object, use the protected `this.create(...)` instead — it shares
-the current `Page` and routes through the same registry, which is what lets
-page objects reference each other without importing each other's classes as
-values (avoiding circular imports). Use `import type` only for annotations:
+the current `Page` and goes through the same registry. Import the sibling's type
+for the return annotation:
 
 ```ts
 import { BasePageObject } from "@qawolf/pom";
@@ -108,7 +125,9 @@ export class DashboardPage extends BasePageObject {
 ```
 
 `create` / `createPage` are async because lazily registered modules load on
-first use.
+first use. Importing `SettingsPage` and calling
+`SettingsPage.createFromPage(this.page)` is the synchronous alternative, and
+needs no registry entry and no separate return-type annotation.
 
 ### Typing `this.create(...)`
 
@@ -179,8 +198,10 @@ export class CookieBannerPage extends BasePageObject {
 }
 ```
 
-`installPageHooks()` collects these across **every** registered page object,
-not just the entry point. Overrides are detected by an own-property check on the
+`installPageHooks()` collects these across **every** registered page object, not
+just the entry point — so register a page object that owns popups or routes even
+when your code only ever constructs it from a direct import. Its hooks never
+install otherwise. Overrides are detected by an own-property check on the
 registered class's prototype, so declare `popupHandlers()` /
 `routeInterceptors()` directly on the class you register — an override inherited
 from a base class is not picked up.

--- a/qawolf/libraries/pom/troubleshooting.mdx
+++ b/qawolf/libraries/pom/troubleshooting.mdx
@@ -25,13 +25,32 @@ Check:
 - the name is registered in exactly one place
 - two page objects are not registered under the same name
 
-## A Page Object's Popup Or Route Hook Never Runs
+## `Cannot access '<name>' before initialization`
 
-Cause: Page hooks are collected by an own-property check on the **registered**
-class's prototype, so an override inherited from a base class is not detected.
+Cause: Two files import each other, and one of them uses the other's class while
+that file is still loading — almost always a page object that `extend`s a class
+declared in a file importing it back. Two page objects that import each other
+are fine; extending across that pair is not, because the file that loads second
+evaluates `extends` before the class exists.
 
 Check:
 
+- the base class lives in a file that imports neither of the two page objects
+- nothing else in the cycle runs at module top level against an imported
+  binding — using it inside a method body is fine, since both files have
+  finished loading by then
+
+## A Page Object's Popup Or Route Hook Never Runs
+
+Cause: The page object is not registered, or page hooks are collected by an
+own-property check on the **registered** class's prototype and the override is
+inherited from a base class.
+
+Check:
+
+- the page object is passed to `registerPage`, even if your code only ever
+  constructs it from a direct import — `installPageHooks()` walks the registry
+  and cannot see an unregistered class
 - `popupHandlers()` / `routeInterceptors()` is declared directly on the class
   passed to `registerPage`, not only on a base class it extends
 - the entry point calls `installPageHooks()` before navigating


### PR DESCRIPTION
The `@qawolf/pom` docs said page objects must never import one another, and that the page registry was the only way for one to construct another. That came from a QA Wolf runner restriction on import cycles which no longer applies.

The API reference now shows both ways to construct a sibling page object and says when each one fits: import it and call `SiblingPage.createFromPage(this.page)`, or look it up by registered name with `this.create("SiblingPage")`, which keeps the sibling's module out of the caller's import graph until the first construction.

The registry section states the job direct imports cannot take over — `installPageHooks()` walks the registry, so a page object that owns popups or routes needs an entry there even when nothing constructs it by name. That is now also the first thing to check under "A Page Object's Popup Or Route Hook Never Runs".

Troubleshooting gains an entry for `Cannot access '<name>' before initialization`, the one cycle shape that still cannot load: a page object extending a class declared in a file that imports it back.

Pairs with [qawolf/pom#9](https://github.com/qawolf/pom/pull/9), which makes the same change in the package's own README and JSDoc.
