### PR TITLE
docs(pom): create() falls back to BasePageObject, not any

### DIFF
--- a/qawolf/libraries/pom/api-reference/index.mdx
+++ b/qawolf/libraries/pom/api-reference/index.mdx
@@ -112,10 +112,11 @@ first use.
 
 ### Typing `this.create(...)`
 
-By default `this.create("LoginPage")` returns `any`. Augment the
+By default `this.create("LoginPage")` returns `BasePageObject` — the name is
+just a string, so nothing tells TypeScript which class comes back. Augment the
 `RegisteredPages` interface — declared for exactly this purpose — to make the
 name-to-type mapping known, and `create` becomes fully typed. This is
-incremental: names you don't list keep the `any` fallback.
+incremental: names you don't list still come back as `BasePageObject`.
 
 ```ts
 import type { LoginPage } from "./pages/login-page.js";

--- a/qawolf/libraries/pom/troubleshooting.mdx
+++ b/qawolf/libraries/pom/troubleshooting.mdx
@@ -49,9 +49,11 @@ Check:
 - drop `{ providesPageHooks: false }` from that registration so its hooks are
   installed
 
-## `this.create("X")` Is Typed As `any`
+## `this.create("X")` Returns `BasePageObject` Instead Of `X`
 
-Cause: The name is not present in the `RegisteredPages` map.
+Cause: The name is not present in the `RegisteredPages` map, so `create` falls
+back to its default return type of `BasePageObject` and `X`'s own methods are
+not visible.
 
 Check:
 


### PR DESCRIPTION
The POM docs said an unregistered page name makes `this.create("X")` return `any`. It returns `BasePageObject` — the library's fallback overload defaults to it, and the type tests assert it. Anyone reading the docs would expect no type checking at all on those calls, when they actually get the base class.

- The API reference now says an unlisted name comes back as `BasePageObject`, and explains why: the name is just a string, so nothing tells TypeScript which class it is.
- The troubleshooting entry is retitled "`this.create("X")` Returns `BasePageObject` Instead Of `X`" and says the methods you're missing are the ones on your own class. Nothing linked to the old anchor.