### PR TITLE
Improve Automate tips and add reusable AI knowledge (SKILL.md) page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -114,6 +114,7 @@
             "pages": [
               "qawolf/Automate-flows-using-AI-2d35b2a994fb8084b524cfc9aca7c358",
               "qawolf/getting-the-most-out-of-automate",
+              "qawolf/reusable-ai-knowledge",
               "qawolf/anatomy-of-a-qa-wolf-test-mobile-edition",
               "qawolf/Create-a-new-flow-2c15b2a994fb802193a5c05e0219eb59",
               "qawolf/Use-the-Elements-picker-2c35b2a994fb80a681baca4f6acf3179",

--- a/qawolf/getting-the-most-out-of-automate.mdx
+++ b/qawolf/getting-the-most-out-of-automate.mdx
@@ -5,34 +5,83 @@ icon: "lightbulb"
 sidebarTitle: "Get the most out of Automate"
 ---
 
-Automate works best when you give it enough context to understand what you want and where to put it. The tips below cover both autonomous creation and guided creation.
+Automate works best when you give it enough context to understand what you want and where to put it. It supports two ways of working:
+
+<CardGroup cols={2}>
+  <Card title="Autonomous creation" icon="rocket" href="#autonomous-creation">
+    No human in the loop. Front-load all the context into one prompt, hit run, and review the finished flow.
+  </Card>
+  <Card title="Guided creation" icon="handshake" href="#guided-creation">
+    A copilot workflow. Prompt for one small change at a time, discovering the app together with the AI.
+  </Card>
+</CardGroup>
+
+Both modes benefit from context you write down once. If you find yourself repeating the same background across sessions, put it in a [SKILL.md](/qawolf/reusable-ai-knowledge).
 
 ## Autonomous creation
+
+In this mode Automate works unattended, so everything it needs to know has to be in the prompt before you hit run.
 
 ### Write a specific prompt
 
 Vague prompts produce unreliable results. A prompt like "Create a test for the rate quote flow" gives Automate very little to work with. A stronger prompt includes:
 
-- Where to start (URL or a reference to a login helper)
+- Where to start (URL and login credentials)
 - What the user does, step by step
 - What a successful outcome looks like
 - Anything specific you want asserted
 
 **Example:**
 
-```text
-Create a test for completing the rate quote application. Log in using the
-<specific name> login helper from <file where helper function is>.ts. Navigate to the application, fill in the required fields, and submit. Assert that the confirmation 
-message appears and that the new rate quote is visible in the list.
+```handlebars wrap
+Create a test for the rate quote application. Go to {{your app URL}} and sign in with {{test user email}} and {{test user password}}. Navigate to the rate quote form, fill in the required fields, and submit. Assert that the confirmation message appears and that the new rate quote is visible in the list.
 ```
 
 ### Include assertions explicitly
 
 If there's something specific you need verified, say so. Automate won't always infer what matters to you — telling it what to assert produces more useful tests.
 
+### Link your app's documentation
+
+If a flow depends on setup that is only explained in your documentation, include the link in the flow description or your prompt. The AI reads linked documentation before it starts building and uses it to complete configuration steps it cannot discover from the UI alone.
+
+```handlebars wrap
+Create a test for connecting a Jira project. Follow the setup guide at {{your docs URL}} to configure the integration first.
+```
+
+### Structure the flow header around Arrange, Act, Assert
+
+When Automate completes a flow on its own, the comment block at the top of the flow is its specification. Structuring that header around [Arrange, Act, Assert](/qawolf/anatomy-of-a-qa-wolf-test-mobile-edition#the-aaa-framework) tells Automate how far each verification should go.
+
+For example, a flow that disables a feature could simply reload the page and check that the toggle is still off. It could also go further and sign in as a different user to verify the feature is no longer accessible. An AAA header states which one you want, so Automate doesn't have to guess:
+
+```typescript
+/**
+ * Goal: Editor project transfers
+ *
+ * Test 1:
+ * Arrange: Log in as an enterprise owner and an enterprise editor. As the
+ *   owner, enable editor project transfers in workspace settings under
+ *   Privacy and Security.
+ * Act: As the editor, open the owner's project and go to project settings.
+ * Assert: The Move button is enabled.
+ *
+ * Test 2:
+ * Arrange: As the owner, disable editor project transfers.
+ * Act: As the editor, reload project settings.
+ * Assert: The Move button is disabled; check the tooltip content.
+ */
+```
+
+### Use descriptive flow names
+
+Before building a new flow, the AI searches your workspace for similar flows and reuses the parts that overlap instead of starting from scratch. Descriptive names help it find the right ones. If you want it to work from a specific example, [point it at a working reference](#point-automate-at-a-working-reference).
+
 ---
 
 ## Guided creation
+
+In this mode you stay in the loop, hand-holding Automate to completion. Use it when you don't have the full context yourself and are discovering the app at the same time as the AI, so it makes sense to work the problem together.
 
 ### Start prompts with "Insert code to"
 
@@ -48,6 +97,12 @@ Automate inserts code relative to the current cursor position. If code ends up i
 
 - Click on the line where you want the code inserted before prompting
 - Or tell it explicitly: "Insert code on line 42 to..."
+
+### Describe elements in plain language
+
+You don't need to tell Automate which Playwright locator to use. It's better at finding the most relevant locator itself. If you prescribe a locator and it turns out not to work, Automate gets stuck between obeying your instruction and producing a working test, and the result suffers.
+
+Say _"Click the Save button in the billing settings panel"_, not _"Click `page.locator('#btn-save-2')`"_.
 
 ### Hover before you prompt for elements
 
@@ -101,8 +156,8 @@ Automate will read the error output and attempt a fix.
 
 If you have a working example that you want Automate AI to follow, simply give it the path to that file and tell it what you'd like it to copy.
 
-```text
-Use the new apiLogin method as exemplified in this file: <path to file>
+```handlebars
+Use the new apiLogin method as exemplified in this file: {{path to file}}
 ```
 
 This will prevent having to re-describe the change each time.

--- a/qawolf/getting-the-most-out-of-mapping.mdx
+++ b/qawolf/getting-the-most-out-of-mapping.mdx
@@ -50,3 +50,7 @@ Mapping is designed for breadth — getting a full outline of an app's testable 
 <Tip>
   A common pattern: run Mapping to generate a broad outline, then use Automate to build out the flows that need more precision.
 </Tip>
+
+## Write down what you repeat
+
+If every mapping session needs the same background about your app, put it in a [SKILL.md](/qawolf/reusable-ai-knowledge). The agent starts each session with that knowledge instead of rediscovering it.

--- a/qawolf/reusable-ai-knowledge.mdx
+++ b/qawolf/reusable-ai-knowledge.mdx
@@ -1,0 +1,71 @@
+---
+title: "Give the AI reusable knowledge with SKILL.md"
+description: "Package knowledge about your app in SKILL.md files that the AI loads in every session."
+icon: "graduation-cap"
+sidebarTitle: "Reusable AI knowledge"
+---
+
+Prompts teach the AI about your app one session at a time. A skill makes that knowledge permanent. SKILL.md files are loaded in every autonomous creation, guided creation, and mapping session, so the AI starts with your context instead of asking you to repeat it.
+
+## What a skill looks like
+
+A skill is a Markdown file with two parts: frontmatter that names and describes it, and a body with the knowledge itself.
+
+```markdown
+---
+name: acme-conventions
+description: Domain terms and test conventions for the Acme app
+---
+
+# Logging in
+
+Always sign in through the SSO tile. The email and password form is
+deprecated and fails for most test users.
+
+# Domain terms
+
+- A "quote" is a rate quote, not a chat message.
+- "Members" and "subscribers" are the same object in the UI.
+
+# Conventions
+
+- Structure every flow header around Arrange, Act, Assert.
+- Prefer unique generated values over hardcoded ones for new records.
+```
+
+## Where skills live
+
+A skill can live anywhere in your workspace. The best practice is to give each SKILL.md its own folder:
+
+```text
+your-workspace/
+├── skills/
+│   ├── acme-conventions/
+│   │   └── SKILL.md
+│   └── payments-testing/
+│       └── SKILL.md
+├── src/
+│   ├── flows/
+│   └── pages/
+├── package.json
+└── tsconfig.json
+```
+
+## What belongs in a skill
+
+Good skill content is anything you would otherwise repeat across many prompts:
+
+- Domain vocabulary and what each term maps to in the UI
+- Environment quirks, such as which login method works and which test users are seeded
+- Team conventions, such as [structuring flow headers around AAA](/qawolf/getting-the-most-out-of-automate#structure-the-flow-header-around-arrange-act-assert)
+- Links to deeper documentation the AI should fetch when it becomes relevant
+
+Keep each skill focused on one topic. Knowledge that matters to a single flow belongs in that flow's prompt or header, not in a skill.
+
+## How each surface uses skills
+
+**Autonomous creation.** The quality of an unattended run depends on the context you front-load. A skill carries the standing context, so your prompt only needs to describe the flow itself.
+
+**Guided creation.** You stop re-explaining the same background at every step. The AI already knows your domain terms and conventions, so short prompts land correctly.
+
+**Mapping.** The agent explores your app already knowing what the features are called and which areas matter, which produces more accurate flow stubs.


### PR DESCRIPTION
## Summary

**Get the most out of Automate**
- Define autonomous vs guided creation upfront (linked cards) and open each section with what the mode is for
- New tips:
  - Structure the flow header around Arrange, Act, Assert
  - Describe elements in plain language instead of dictating locators
  - Link your app's documentation (the AI reads linked docs before building)
  - Use descriptive flow names (the AI reuses similar flows before starting)
- Example prompt now uses URL and credentials instead of a named login helper, so it works for someone with no prior setup
- Template placeholders are highlighted via handlebars fences ({{like this}}); long example prompts soft-wrap instead of scrolling

**New page: Give the AI reusable knowledge with SKILL.md**
- What a skill is, where skills live (one folder per SKILL.md), what belongs in one, and how each AI surface uses them
- Added to the Automate nav group, cross-linked from the Automate and Mapping tips pages

## Test plan
- Previewed with `mint dev`: all touched pages render, card links, section anchors, and cross-links verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)